### PR TITLE
add dev guide redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -211,6 +211,12 @@ module.exports = {
                         '/celo-holder-guide/celo-recovery'
                     ],
                 },
+                {
+                    to: '/developer-guide/overview',
+                    from: [
+                        '/v/master/developer-guide/overview'
+                    ]
+                }
               ],
             },
         ]

--- a/sidebars.js
+++ b/sidebars.js
@@ -162,7 +162,7 @@ module.exports = {
           ]
         },
         // TODO: This link will need to be changed when we move all the SDK type docs
-        { type: 'link', label: 'SDK Code Reference', href: 'https://docs.celo.org/developer-guide/sdk-code-reference' },
+        // { type: 'link', label: 'SDK Code Reference', href: 'https://docs.celo.org/developer-guide/sdk-code-reference' },
       ]
     },
     {


### PR DESCRIPTION
Redirect links to https://docs.celo.org/v/master/developer-guide/overview to https://docs.celo.org/developer-guide/overview