### PR TITLE
Fix : fix typo

### DIFF
--- a/docs/developer-resources/contractkit/contracts-wrappers-registry.md
+++ b/docs/developer-resources/contractkit/contracts-wrappers-registry.md
@@ -9,7 +9,7 @@ celo-blockchain has two initial coins: CELO and cUSD (stableToken).
 Both implement the ERC20 standard, and to interact with them is as simple as:
 
 ```ts
-const goldtoken = await kit.contract.getGoldToken()
+const goldtoken = await kit.contracts.getGoldToken()
 
 const balance = await goldtoken.balanceOf(someAddress)
 ```


### PR DESCRIPTION
Fix typo in get Gold tokens
kit.contract doesn't have the `getGoldToken` function.

`kit.contract.getGoldToken()` -> `kit.contracts.getGoldToken()`