### PR TITLE
Update web-app developer guide

### DIFF
--- a/docs/developer-resources/walkthroughs/web-dapp.md
+++ b/docs/developer-resources/walkthroughs/web-dapp.md
@@ -36,6 +36,24 @@ Here's what we'll be using each of these packages for:
 - [@celo-tools/use-contractkit](https://github.com/celo-tools/use-contractkit) is a community provided library to ease establishing the connection with a user's wallet, whether that is a hardware, mobile, or web wallet. When developing with this library, your users can hold Celo via [Valora](https://valoraapp.com), a Ledger, Metamask and more
 - [bignumber.js](https://github.com/MikeMcl/bignumber.js/) is a library for expressing large numbers in JavaScript. When interacting with a blockchain we often need to handle arbitrary-precision decimal and non-decimal arithmetic.
 
+We'll also need to add some Next.js config to work with these packages. Update next.config.js with the following:
+```javascript
+module.exports = {
+  webpack: (config) => {
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      fs: false,
+      net: false,
+      child_process: false,
+      readline: false,
+    };
+    return config;
+  },
+};
+```
+
+We'll need to restart the server for the config changes to take effect.
+
 ## Developing the application
 
 After all our boilerplate has been setup, we're ready to start developing our application.

--- a/docs/developer-resources/walkthroughs/web-dapp.md
+++ b/docs/developer-resources/walkthroughs/web-dapp.md
@@ -64,9 +64,12 @@ When a user wants to interact with your DApp we need to somehow allow them to co
 
 Leveraging our previously added [@celo-tools/use-contractkit](https://github.com/celo-tools/use-contractkit) library we can provide a button that prompts the user to connect their wallet.
 
+Update pages/index.js with the following:
 ```javascript
-import React from 'react'
-import { useContractKit } from '@celo-tools/use-contractkit'
+import React from 'react';
+import { useContractKit } from '@celo-tools/use-contractkit';
+import { ContractKitProvider } from '@celo-tools/use-contractkit';
+import '@celo-tools/use-contractkit/lib/styles.css';
 
 function App () {
   const { address, connect } = useContractKit()
@@ -79,6 +82,21 @@ function App () {
     </main>
   )
 }
+
+function WrappedApp() {
+  return (
+    <ContractKitProvider
+      dapp={{
+          name: "My awesome dApp",
+          description: "My awesome description",
+          url: "https://example.com",
+        }}
+    >
+      <App />
+    </ContractKitProvider>
+  );
+}
+export default WrappedApp;
 ```
 
 Clicking this button will show the `use-contractkit` modal and allow the user to connect with their wallet of choice. Once the modal has been dismissed, the `address` property exposed by `use-contractkit` will be filled with the users primary account.

--- a/docs/developer-resources/walkthroughs/web-dapp.md
+++ b/docs/developer-resources/walkthroughs/web-dapp.md
@@ -116,7 +116,7 @@ For the purposes of this tutorial, we'll only be looking at dequeued proposals, 
 Here's how it looks using a combination of the `useEffect` and `useCallback` hooks to request and display all dequeued proposals from the blockchain.
 
 ```javascript
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useContractKit } from '@celo-tools/use-contractkit'
 
 function App() {


### PR DESCRIPTION
Hi, this is my first PR off the Celo docs :)
Essentially I went through the web-app flow described here (https://docs.celo.org/developer-guide/start/web-dapp) and ran into some issues. I've made 3 separate commits to capture the 3 issues I ran into.

1) When I attempted the "Connecting to the user's wallet" section, I got the error "Module not found: Can't resolve 'fs'". Searching the discord channel @AlexBHarley mentioned copying the next.config.js found here: https://github.com/celo-org/use-contractkit/blob/master/packages/example/next.config.js - I used that as the starting point but simplified it a bit for this demo to the minimum required to get things working.

2) I ran into a new error after fixing the next.config.js which was "Error: Components using the use-contractkit hook must be a child of a ContractKitProvider". For that I looked at the example here: https://github.com/celo-org/use-contractkit#wrap-your-application-with-contractkitprovider - and copied the pattern of adding a WrappedApp. Note that when there was not default export I saw the error "Error: The default export is not a React Component in page" so I export the WrappedApp on the last line.

3) I ran into a simple error around a missing dependency "useState".

After these updates everything else ran smoothly (I didn't try the optional Locking Celo section yet).

Let me know if you have any other suggestions, or if there are simpler steps to get everything working that I missed.

Signed-off-by: Jacob Saur <saur.jacob@gmail.com>