### PR TITLE
Add node version

### DIFF
--- a/docs/developer-resources/walkthroughs/hellocontracts.md
+++ b/docs/developer-resources/walkthroughs/hellocontracts.md
@@ -7,7 +7,7 @@ This guide walks you through the basics of how to deploy your own smart contract
 
 ## Setup
 
-This guide assumes that you have a basic Node/[NPM](https://www.npmjs.com/get-npm) setup. If so, you can install truffle with:
+This guide assumes that you have a basic Node/[NPM](https://www.npmjs.com/get-npm) setup (Node.js v12.x). If so, you can install truffle with:
 
 ```
 npm install -g truffle


### PR DESCRIPTION
Hi, I thought it would be useful to include the Node version here. I see it now in other parts of the docs, but this was one of the first ones I tried and was using Node 14. The celo ganache-cli fails with "Error: callback already called", which according to https://support.chainstack.com/hc/en-us/articles/900001783126-Ganache-CLI-fails-with-Error-callback-already-called- is due to running an older version of ganache against Node 14. At some point it would probably be nice to update https://github.com/celo-org/ganache-cli to be in line with the latest ganache, but in the short run specifying Node 12 works fine.

Signed-off-by: Jacob Saur <saur.jacob@gmail.com>