### PR TITLE
add 'en' language files

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,6 +14,10 @@ module.exports = {
     favicon: "img/logo.png",
     organizationName: "celo-org", // Usually your GitHub org/user name.
     projectName: "docs", // Usually your repo name.
+    i18n: {
+        defaultLocale: 'en',
+        locales: ['en']
+    },
     plugins: [
         require.resolve('docusaurus-plugin-fathom'),
         path.resolve(__dirname, 'src/plugins/aliases.ts'),
@@ -295,7 +299,12 @@ module.exports = {
                 alt: "Celo Logo",
                 src: "img/logo.png",
             },
-            items: [{
+            items: [
+                {
+                    type: 'localeDropdown',
+                    position: 'left',
+                },
+                {
                     href: "https://celo.org",
                     label: "Celo Home",
                 },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -1,0 +1,218 @@
+{
+  "theme.NotFound.title": {
+    "message": "Page Not Found",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "We could not find what you were looking for.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Close",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Blog list page navigation",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Newer Entries",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Older Entries",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "One min read|{readingTime} min read",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Read More",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Blog post page navigation",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Newer Post",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Older Post",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "View All Tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copy code to clipboard",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copied",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copy",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Docs pages navigation",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Previous",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Next",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "One doc tagged|{count} docs tagged",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "latest version",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Edit this page",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Direct link to heading",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " on {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " by {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Last updated{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Skip to main content",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "One document found|{count} documents found",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Search results for \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Search the documentation",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Type your search here",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "Search by Algolia",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "No results were found",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Fetching new results...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Search",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  }
+}

--- a/i18n/en/docusaurus-plugin-content-blog/options.json
+++ b/i18n/en/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "Recent posts",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,126 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.docs.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar docs"
+  },
+  "sidebar.docs.category.Wallets": {
+    "message": "Wallets",
+    "description": "The label for category Wallets in sidebar docs"
+  },
+  "sidebar.docs.category.Using MetaMask with Celo": {
+    "message": "Using MetaMask with Celo",
+    "description": "The label for category Using MetaMask with Celo in sidebar docs"
+  },
+  "sidebar.docs.category.Alfajores Testnet": {
+    "message": "Alfajores Testnet",
+    "description": "The label for category Alfajores Testnet in sidebar docs"
+  },
+  "sidebar.docs.category.Baklava Testnet": {
+    "message": "Baklava Testnet",
+    "description": "The label for category Baklava Testnet in sidebar docs"
+  },
+  "sidebar.docs.category.Mainnet": {
+    "message": "Mainnet",
+    "description": "The label for category Mainnet in sidebar docs"
+  },
+  "sidebar.docs.category.Celo Owner Guide": {
+    "message": "Celo Owner Guide",
+    "description": "The label for category Celo Owner Guide in sidebar docs"
+  },
+  "sidebar.docs.category.Using a Ledger Wallet": {
+    "message": "Using a Ledger Wallet",
+    "description": "The label for category Using a Ledger Wallet in sidebar docs"
+  },
+  "sidebar.docs.category.Validator Guide": {
+    "message": "Validator Guide",
+    "description": "The label for category Validator Guide in sidebar docs"
+  },
+  "sidebar.docs.category.Key Management": {
+    "message": "Key Management",
+    "description": "The label for category Key Management in sidebar docs"
+  },
+  "sidebar.docs.category.Developer Guide": {
+    "message": "Developer Guide",
+    "description": "The label for category Developer Guide in sidebar docs"
+  },
+  "sidebar.docs.category.Code Examples": {
+    "message": "Code Examples",
+    "description": "The label for category Code Examples in sidebar docs"
+  },
+  "sidebar.docs.category.ContractKit": {
+    "message": "ContractKit",
+    "description": "The label for category ContractKit in sidebar docs"
+  },
+  "sidebar.docs.category.DAppKit": {
+    "message": "DAppKit",
+    "description": "The label for category DAppKit in sidebar docs"
+  },
+  "sidebar.docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar docs"
+  },
+  "sidebar.docs.category.Celo CLI": {
+    "message": "Celo CLI",
+    "description": "The label for category Celo CLI in sidebar docs"
+  },
+  "sidebar.docs.category.Celo Codebase": {
+    "message": "Celo Codebase",
+    "description": "The label for category Celo Codebase in sidebar docs"
+  },
+  "sidebar.docs.category.Celo Protocol": {
+    "message": "Celo Protocol",
+    "description": "The label for category Celo Protocol in sidebar docs"
+  },
+  "sidebar.docs.category.Consensus": {
+    "message": "Consensus",
+    "description": "The label for category Consensus in sidebar docs"
+  },
+  "sidebar.docs.category.Proof-of-Stake": {
+    "message": "Proof-of-Stake",
+    "description": "The label for category Proof-of-Stake in sidebar docs"
+  },
+  "sidebar.docs.category.Epoch Rewards": {
+    "message": "Epoch Rewards",
+    "description": "The label for category Epoch Rewards in sidebar docs"
+  },
+  "sidebar.docs.category.Stability Mechanism": {
+    "message": "Stability Mechanism",
+    "description": "The label for category Stability Mechanism in sidebar docs"
+  },
+  "sidebar.docs.category.Transactions": {
+    "message": "Transactions",
+    "description": "The label for category Transactions in sidebar docs"
+  },
+  "sidebar.docs.category.Identity": {
+    "message": "Identity",
+    "description": "The label for category Identity in sidebar docs"
+  },
+  "sidebar.docs.category.Celo Wallet": {
+    "message": "Celo Wallet",
+    "description": "The label for category Celo Wallet in sidebar docs"
+  },
+  "sidebar.docs.category.Wallet Functionality": {
+    "message": "Wallet Functionality",
+    "description": "The label for category Wallet Functionality in sidebar docs"
+  },
+  "sidebar.docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar docs"
+  },
+  "sidebar.docs.category. Release Process": {
+    "message": " Release Process",
+    "description": "The label for category  Release Process in sidebar docs"
+  },
+  "sidebar.docs.category.Important Information": {
+    "message": "Important Information",
+    "description": "The label for category Important Information in sidebar docs"
+  },
+  "sidebar.docs.link.SDK Code Reference": {
+    "message": "SDK Code Reference",
+    "description": "The label for link SDK Code Reference in sidebar docs, linking to https://celo-sdk-docs.readthedocs.io/"
+  }
+}

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,0 +1,30 @@
+{
+  "link.title.Docs": {
+    "message": "Docs",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "Community",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.Home": {
+    "message": "Home",
+    "description": "The label of footer link with label=Home linking to /"
+  },
+  "link.item.label.Stack Overflow": {
+    "message": "Stack Overflow",
+    "description": "The label of footer link with label=Stack Overflow linking to https://stackoverflow.com/questions/tagged/celo"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discordapp.com/invite/docusaurus"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/docusaurus"
+  },
+  "copyright": {
+    "message": "Copyright © 2021 Celo Foundation, Inc. Built with Docusaurus.",
+    "description": "The footer copyright"
+  }
+}

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,22 @@
+{
+  "title": {
+    "message": "Celo Docs",
+    "description": "The title in the navbar"
+  },
+  "item.label.Celo Home": {
+    "message": "Celo Home",
+    "description": "Navbar item with label Celo Home"
+  },
+  "item.label.Build": {
+    "message": "Build",
+    "description": "Navbar item with label Build"
+  },
+  "item.label.Faucet": {
+    "message": "Faucet",
+    "description": "Navbar item with label Faucet"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}


### PR DESCRIPTION
This PR adds the files for english (en) i18n language support for docusaurus. 

This was done by running the provided docusaurus command outlined [here](https://docusaurus.io/docs/cli#docusaurus-write-translations-sitedir).