### PR TITLE
update port in docs

### DIFF
--- a/docs/developer-resources/walkthroughs/development-chain.md
+++ b/docs/developer-resources/walkthroughs/development-chain.md
@@ -17,12 +17,12 @@ The easiest is to use a "pre-generated" devchain from the [celo-devchain](https:
 
 ```sh
 > npm install --save-dev celo-devchain
-> npx celo-devchain --port 7545
+> npx celo-devchain --port 8545
 
 or
 
 > yarn add --dev celo-devchain
-> yarn run celo-devchain --port 7545
+> yarn run celo-devchain --port 8545
 ```
 
 ### 2. Initialize your own devchain from the monorepo


### PR DESCRIPTION
I'm not 100% sure if this is correct, however on this page the port values of 7545 and 8545 were both used which was confusing. I tried to start the cel-devchain with port 7545 and the celocli was unable to connect to the chain, but when I used 8545 it was able to connect. Since 8545 is also used on the rest of this page this seems like a safe change to suggest.

Signed-off-by: Jacob Saur <saur.jacob@gmail.com>