### PR TITLE
Tiny spelling fix for EN documentation.

### DIFF
--- a/docs/developer-resources/celo-for-eth-devs.md
+++ b/docs/developer-resources/celo-for-eth-devs.md
@@ -20,7 +20,7 @@ For a general overview of the Celo network and architecture, see [the Celo Overv
 ## What is Celo's Relationship to Ethereum?
 
 Celo is a layer 1 protocol and blockchain platform, and the Celo Mainnet is entirely separate from the Ethereum network.
-While the Celo client originated as a fork of Ethereum Go langauge client, [go-ethereum](https://github.com/ethereum/go-ethereum) (or geth), it has several significant differences, including a proof-of-stake based PBFT consensus mechanism. All the cryptoassets on Celo have ERC-20 compliant interfaces, meaning that while they are not ERC-20 tokens on the Ethereum Mainnet, all familiar tooling and code that support ERC-20 tokens can be easily adapted for Celo assets, including the Celo Native Asset (CELO) and the Celo Dollar (cUSD). 
+While the Celo client originated as a fork of Ethereum Go language client, [go-ethereum](https://github.com/ethereum/go-ethereum) (or geth), it has several significant differences, including a proof-of-stake based PBFT consensus mechanism. All the cryptoassets on Celo have ERC-20 compliant interfaces, meaning that while they are not ERC-20 tokens on the Ethereum Mainnet, all familiar tooling and code that support ERC-20 tokens can be easily adapted for Celo assets, including the Celo Native Asset (CELO) and the Celo Dollar (cUSD).
 
 In terms of programmability, Celo is similar to Ethereum. Both networks run the Ethereum Virtual Machine (EVM) to support smart contract functionality. 
 This means that all programming languages, developer tooling and standards that target the EVM are relevant for both Celo and Ethereum. 


### PR DESCRIPTION
subbing s/langauge/language/g