### PR TITLE
docs: added await for promise

### DIFF
--- a/docs/developer-resources/contractkit/data-encryption-key.md
+++ b/docs/developer-resources/contractkit/data-encryption-key.md
@@ -18,7 +18,7 @@ When using the DEK, it's important to check that the DEK is the latest that's re
 ```ts
   // Query the on-chain data encryption key for a user
   const accountWrapper: AccountsWrapper = await contractKit.contracts.getAccounts()
-  const dataEncryptionKey = accountWrapper.getDataEncryptionKey(address)
+  const dataEncryptionKey = await accountWrapper.getDataEncryptionKey(address)
   // Check that this matches with the public key
   ...
 ```


### PR DESCRIPTION
In the example code, there should be an `await` before `accountWrapper.getDataEncryptionKey` since it returns a promise