### PR TITLE
Remove Tauros wallet from documentation

### DIFF
--- a/docs/getting-started/wallets/index.md
+++ b/docs/getting-started/wallets/index.md
@@ -124,11 +124,6 @@ Strictly speaking, wallet connect is not a wallet; it is an open protocol for co
 - [https://www.pandapay.ca/en/](https://www.pandapay.ca/en/)
 - Countries: Brazil
 
-### Tauros
-
-- [https://tauros.shop/](https://tauros.shop/)
-- Countries: Mexico
-
 ### Kanzu Banking
 
 - [https://kanzucode.com/](https://kanzucode.com/)


### PR DESCRIPTION
Remove Tauros wallet from documentation as per request https://celo-org.slack.com/archives/CQGG1SYLQ/p1640637720261100.