### PR TITLE
Top level nav

### DIFF
--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -8,37 +8,36 @@ id: faqs
 
 Answers to frequently asked questions about Celo.
 
-___
+---
 
 ## Introduction and Overview
 
-
 ### What is Celo (CELO)?
 
-Celo is an open platform that makes financial tools accessible to anyone with a mobile phone. Celo is a mobile-first platform that makes financial dApps and crypto payments accessible to  anyone with a mobile phone  Let's dig a little deeper into some of the terms:
+Celo is an open platform that makes financial tools accessible to anyone with a mobile phone. Celo is a mobile-first platform that makes financial dApps and crypto payments accessible to anyone with a mobile phone Let's dig a little deeper into some of the terms:
 
 **Open**
 
-* The platform is an open-source project where everyone is invited to contribute
-* Celo is connecting to decentralized ecosystems like Ethereum, Bitcoin, and Cosmos, and improving blockchain interoperability with Optics
+- The platform is an open-source project where everyone is invited to contribute
+- Celo is connecting to decentralized ecosystems like Ethereum, Bitcoin, and Cosmos, and improving blockchain interoperability with Optics
 
 **Mobile**
 
-* Phone numbers are mapped to addresses using a decentralized identity protocol, which facilitates the user experience
-* The ultra-light client allows all smartphones, including those with low memory and connectivity, to easily connect to the Celo network
+- Phone numbers are mapped to addresses using a decentralized identity protocol, which facilitates the user experience
+- The ultra-light client allows all smartphones, including those with low memory and connectivity, to easily connect to the Celo network
 
 **Real**
 
-* The platform is designed with communities around the world where are innovations are based on 150+ user interviews in 20+ cities across 10+ countries
-* Celo hosts a rich ecosystem of dApps, from DeFI to payments, catering to users across 6 continents
-* Celo is a blockchain ecosystem focused on increasing cryptocurrency adoption among smartphone users.
-* By using phone numbers as public keys, Celo hopes to introduce the world’s billions of smartphone owners, including those without banking access, to transacting in cryptocurrency.
+- The platform is designed with communities around the world where are innovations are based on 150+ user interviews in 20+ cities across 10+ countries
+- Celo hosts a rich ecosystem of dApps, from DeFI to payments, catering to users across 6 continents
+- Celo is a blockchain ecosystem focused on increasing cryptocurrency adoption among smartphone users.
+- By using phone numbers as public keys, Celo hopes to introduce the world’s billions of smartphone owners, including those without banking access, to transacting in cryptocurrency.
 
 ### When was Celo Launched?
 
 The project started in the fall of 2017 when the whitepaper was first published. The first test network, called Alfajores (named after the famous Argentian cookie), launched in July 2019. The incentivized testnet, called Baklava (named after the delicious Turkish dessert), launched in December 2019. Mainnet launched on Earth Day Apr 22, 2020.
 
-Today Alfajores is a testnet for dApp developers and Baklava a testnet for node operators. 
+Today Alfajores is a testnet for dApp developers and Baklava a testnet for node operators.
 
 ### Who are the Founders of Celo?
 
@@ -46,11 +45,9 @@ Celo was originally founded by a team comprised of people from MIT, Stanford, Go
 
 Separate entities are aimed at Celo’s promotion and preservation. The dedicated Celo Foundation is a non-profit which launched along with the mainnet, while the Celo Alliance for Prosperity is what the company describes as an “ecosystem of mission-aligned organizations.”
 
-
 ### Where can I see a list with all the apps developed on Celo?
 
 [Celo DApp Gallery](./developer-guide/celo-dapp-gallery)
-
 
 ### What is the unique selling point of Celo?
 
@@ -110,7 +107,7 @@ In addition, up to 120 million CELO will go towards a reserve designed to mainta
 
 Celo uses proof-of-stake to maintain security and has a complex election process to determine validators of its blockchain. Holders of CELO are able to use their holdings as a means of participating in elections by voting for groups of validators.
 
-### Regarding Celo Blockchain, do we have another source for on-chain data apart from [explorer.celo.org](https://explorer.celo.org/)? 
+### Regarding Celo Blockchain, do we have another source for on-chain data apart from [explorer.celo.org](https://explorer.celo.org/)?
 
 [https://www.thecelo.com/](https://www.thecelo.com/) is an alternative source for on-chain data.
 
@@ -132,9 +129,9 @@ For DeFi - today the easiest experience is to visit a dApp’s website and eithe
 
 ## Staking Questions
 
-### How do I  stake CELO?
+### How do I stake CELO?
 
-You can stake CELO via [CeloWallet.app](https://celowallet.app/), [CeloVote.com](https://celovote.com/), [Celo.dance](https://celo.dance/), or [Celoterminal.com](https://celoterminal.com/). 
+You can stake CELO via [CeloWallet.app](https://celowallet.app/), [CeloVote.com](https://celovote.com/), [Celo.dance](https://celo.dance/), or [Celoterminal.com](https://celoterminal.com/).
 
 ### Can people without technical knowledge also participate in the staking process?
 
@@ -156,7 +153,7 @@ Staking tokens in a pool gives you a token called a liquidity provider token (or
 
 ### How can I provide liquidity and farm tokens of Celo’s ecosystem?
 
-[Ubeswap](https://ubeswap.org/) (more info [here](https://docs.ubeswap.org/tutorial/providing-liquidity))and [SushiSwap](https://sushi.com/) offer liquidity provision and farming functionalities on Celo. 
+[Ubeswap](https://ubeswap.org/) (more info [here](https://docs.ubeswap.org/tutorial/providing-liquidity))and [SushiSwap](https://sushi.com/) offer liquidity provision and farming functionalities on Celo.
 
 ### What about borrowing, lending, and interest-earning on Celo?
 
@@ -172,12 +169,12 @@ As with any new technology, not all risks can be eliminated. Some of them are sm
 
 ### How is Celo different from Ethereum?
 
-You can see the key differences between Celo and Ethereum [here](./developer-guide/celo-for-eth-devs). 
+You can see the key differences between Celo and Ethereum [here](./developer-guide/celo-for-eth-devs).
 
 ### When building for mobile, what native SDKs are available?
 
-* [Java](https://github.com/blaize-tech/celo-sdk-java)  
+- [Java](https://github.com/blaize-tech/celo-sdk-java)
 
 ### When building for web2 what SDKs or libraries are available?
 
-A basic example of using wallet connect with Valora can be found [here](/developer-resources/walkthroughs/valora-wc-v1). If you prefer more granular control, take a look at [use-contractkit](https://github.com/celo-tools/use-contractkit). 
+A basic example of using wallet connect with Valora can be found [here](/developer-resources/walkthroughs/valora-wc-v1). If you prefer more granular control, take a look at [use-contractkit](https://github.com/celo-tools/use-contractkit).

--- a/docs/celo-holder-guide/overview.md
+++ b/docs/celo-holder-guide/overview.md
@@ -1,0 +1,44 @@
+---
+title: Use Celo
+description: Download a wallet, manage Celo assets, and start using the Celo network.
+---
+
+import PageRef from '@components/PageRef'
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Use Celo
+
+Download a wallet, manage Celo assets, and start using the Celo network.
+
+---
+
+[Celo](https://celo.org/) users have access to a wide variety of tools, assets, and capabilities provided by the Celo Network. Install a Celo wallet, get Celo assets, and use the Celo protocol to send, spend, bridge, or connect assets with any Celo application.
+
+:::tip
+
+Not ready to use Celo? [Learn more about Celo](../../docs/welcome.md).
+
+:::
+
+## Get CELO
+
+<PageRef url="/getting-started/wallets" pageName="Download a Wallet" />
+<PageRef url="/celo-holder-guide/owners" pageName="Get CELO" />
+
+## Use the Platform
+
+<PageRef url="/celo-codebase/protocol" pageName="Celo Protocol" />
+<PageRef url="/getting-started/choosing-a-network" pageName="Networks" />
+<PageRef url="/command-line-interface/introduction" pageName="Command Line" />
+
+## Advanced Features
+
+<PageRef url="/celo-codebase/protocol/bridging/bridging-to-celo" pageName="Bridging" />
+<PageRef url="/celo-codebase/protocol/oracles/oracles-on-celo" pageName="Oracles" />
+
+:::tip
+
+For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
+
+:::

--- a/docs/celo-holder-guide/owners.md
+++ b/docs/celo-holder-guide/owners.md
@@ -1,5 +1,5 @@
 ---
-title: Celo Owners
+title: Get CELO
 description: Start sending, spending, and earning crypto from your mobile phone
 ---
 
@@ -7,19 +7,13 @@ import PageRef from '@components/PageRef'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Celo Owners
+# Get CELO
 
 Start sending, spending, and earning crypto from your mobile phone.
 
-___
+---
 
 [Celo Owners](https://celo.org/buy) can start transacting with 6 billion other smartphone users around the world from your phone and on the go. Transact in seconds — at a fraction of the cost of other crypto platforms. Anyone who holds any amount of CELO is empowered to vote on governance proposals that direct how the core technology operates today and in the future.
-
-:::tip
-
-Not ready to become a Celo Holder? [Learn more about Celo](../../docs/welcome.md).
-
-:::
 
 ## Discover CELO
 
@@ -35,7 +29,6 @@ CELO is listed on 20+ exchanges worldwide.
 <PageRef url="/celo-owner-guide/cusd" pageName="Asset Management" />
 <PageRef url="/celo-owner-guide/release-gold" pageName="Understand ReleaseGold" />
 <PageRef url="/celo-owner-guide/celo-exchange-bot" pageName="Exchange Celo Assets" />
-
 
 ## Voting as a Celo Owner
 
@@ -53,4 +46,3 @@ CELO is listed on 20+ exchanges worldwide.
 For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 
 :::
-

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -1,5 +1,5 @@
 ---
-title: Celo Community
+title: Celo Contributors
 description: Join a community of developers, designers, dreamers, and doers building prosperity for everyone.
 ---
 
@@ -7,21 +7,21 @@ import PageRef from '@components/PageRef'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Celo Community
+# Celo Contributors
 
 Join a community of developers, designers, dreamers, and doers building prosperity for everyone.
 
-___
+---
 
 Celo is a decentralized community of creators -- developers, designers, dreamers, doers -- who are motivated by the power of accessible financial tools to make the world a better place. We are guided by [Celo's Core tenets](https://celo.org/community).
 
 :::tip
 
-Not ready to join the Celo Community? [Learn more about Celo](../../docs/welcome.md).
+Not ready to become a Celo Contributor? [Learn more about Celo](../../docs/welcome.md).
 
 :::
 
-## Get Started with the Celo Community
+## Get Started as a Celo Contributor
 
 Find your purpose and join a community focused on building the conditions of prosperity—for everyone
 
@@ -36,4 +36,3 @@ Find your purpose and join a community focused on building the conditions of pro
 For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 
 :::
-

--- a/docs/community/join-the-community.md
+++ b/docs/community/join-the-community.md
@@ -2,43 +2,44 @@
 title: Join the Celo Community
 description: Find Celo on social media, contribute to the codebase, or chat with the community.
 ---
+
 # Join the Community
 
 Find Celo on social media, contribute to the codebase, or chat with the community.
 
-___
+---
 
 ## Follow
 
 Follow on Social Media to learn more about Celo.
 
-* [Blog](https://medium.com/celoOrg)
-* [GitHub](https://github.com/celo-org/celo-monorepo)
-* [Twitter](https://twitter.com/CeloOrg)
-* [Forum](https://forum.celo.org/)
-* [Chat](https://discord.gg/6yWMkgM)
-* [YouTube](https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw)
-* [Instagram](https://www.instagram.com/celoorg/)
-* [LinkedIn](https://www.linkedin.com/company/celoOrg/)
-* [Twitch](https://www.twitch.tv/celoorg)
-* [Reddit](https://www.reddit.com/r/celo/)
-* [Telegram](https://t.me/celoplatform)
-
-## Contribute
-
-Browse the code, raise an issue, or contribute a pull request.
-
-* [Monorepo GitHub Page](https://github.com/celo-org/celo-monorepo)
-* [Celo Client GitHub Page](https://github.com/celo-org/celo-blockchain)
-* [Contributing Guide](https://docs.celo.org/community/contributing)
-* [Celo Build Page](https://celo.org/build)
+- [Blog](https://medium.com/celoOrg)
+- [GitHub](https://github.com/celo-org/celo-monorepo)
+- [Twitter](https://twitter.com/CeloOrg)
+- [Forum](https://forum.celo.org/)
+- [Chat](https://discord.gg/6yWMkgM)
+- [YouTube](https://youtube.com/channel/UCCZgos_YAJSXm5QX5D5Wkcw)
+- [Instagram](https://www.instagram.com/celoorg/)
+- [LinkedIn](https://www.linkedin.com/company/celoOrg/)
+- [Twitch](https://www.twitch.tv/celoorg)
+- [Reddit](https://www.reddit.com/r/celo/)
+- [Telegram](https://t.me/celoplatform)
 
 ## Connect
 
 Ask questions, find answers, and get in touch.
 
-* [Celo Forum](https://forum.celo.org/)
-* [Celo Developer Chat on Discord](https://chat.celo.org/)
-* [Celo Subreddit](https://www.reddit.com/r/celo/)
-* [Celo Website](https://celo.org/build)
-* [Host a Meetup](https://airtable.com/shrTCM7LddTxOm3r6)
+- [Celo Forum](https://forum.celo.org/)
+- [Celo Developer Chat on Discord](https://chat.celo.org/)
+- [Celo Subreddit](https://www.reddit.com/r/celo/)
+- [Celo Website](https://celo.org/build)
+- [Host a Meetup](https://airtable.com/shrTCM7LddTxOm3r6)
+
+## Contribute
+
+Browse the code, raise an issue, or contribute a pull request.
+
+- [Monorepo GitHub Page](https://github.com/celo-org/celo-monorepo)
+- [Celo Client GitHub Page](https://github.com/celo-org/celo-blockchain)
+- [Contributing Guide](https://docs.celo.org/community/contributing)
+- [Celo Build Page](https://celo.org/build)

--- a/docs/learn/celo-highlights.md
+++ b/docs/learn/celo-highlights.md
@@ -1,12 +1,13 @@
 ---
-title: Celo Highlights
+title: Key Concepts
 description: Summary of benefits, features, and data behind the Celo platform.
 ---
-# Highlights
+
+# Key Concepts
 
 Summary of benefits, features, and data behind the Celo platform.
 
-___
+---
 
 ## The Platform for Mobile DeFi
 
@@ -16,48 +17,49 @@ The Celo protocol also includes mechanisms for [lightweight identity](../celo-co
 
 **Innovative tools to build native mobile dApps:**
 
-* Stable Value Currencies
-* Phone Number Public Key Infrastructure
-* On-chain Governance
-* Self Custody
-* Proof-of-Stake
-* Open-source 
-* Permissionless
-* High Speed Sync for Ultra-light Clients
-* Gas Payable in Multiple Stablecoins 
-* Programmable (full EVM Compatibility)
+- Stable Value Currencies
+- Phone Number Public Key Infrastructure
+- On-chain Governance
+- Self Custody
+- Proof-of-Stake
+- Open-source
+- Permissionless
+- High Speed Sync for Ultra-light Clients
+- Gas Payable in Multiple Stablecoins
+- Programmable (full EVM Compatibility)
 
 ## Optimized for Financial Applications
 
-Powered by Celo’s industry-leading decentralized phone number verification, payment applications built on Celo allow users to easily send or request digital currencies  from  any mobile number, anywhere in the world, capable of offering their users features like:
+Powered by Celo’s industry-leading decentralized phone number verification, payment applications built on Celo allow users to easily send or request digital currencies from any mobile number, anywhere in the world, capable of offering their users features like:
 
-* Non-custodial wallets
-* Ultra low network transaction fees
-* Digital currency exchange capabilities 
-* QR Code Support
-* Mobile first SDK
+- Non-custodial wallets
+- Ultra low network transaction fees
+- Digital currency exchange capabilities
+- QR Code Support
+- Mobile first SDK
 
 ## Core Contracts
 
 Designed to support an ecology of stable value currencies. The first stablecoin, cUSD, tracks the value of the US Dollar.
 
-* Algorithmic reserve-backed stabilization mechanism
-* Crypto-asset collateralized
-* Native support for multiple stablecoins
+- Algorithmic reserve-backed stabilization mechanism
+- Crypto-asset collateralized
+- Native support for multiple stablecoins
 
 ## Blockchain
 
 Open source permissionless smart contract platform built on decentralized infrastructure.
 
-* Proof-of-Stake based consensus with high throughput, low latency, and zero carbon
-* Incentives for serving mobile devices
-* On-chain governance
+- Proof-of-Stake based consensus with high throughput, low latency, and zero carbon
+- Incentives for serving mobile devices
+- On-chain governance
 
 ## Build on Celo
 
 Visit [celo.org](https://celo.org) to learn more.
 
-___
+---
+
 ## Details
 
 Celo is a mobile-first, carbon-neutral blockchain that makes decentralized financial (DeFi) tools and services accessible to anyone with a mobile phone–bringing the powerful benefits of DeFi to the users of the 6 billion smartphones in circulation today.
@@ -94,7 +96,8 @@ Celo includes a programmable smart contract platform that is compatible with the
 
 Users have access to and fully control their funds and account keys, and don't need to depend on third parties to make payments.
 
-___
+---
+
 ## Metrics
 
 **Validators**
@@ -109,11 +112,11 @@ You can view more detailed information about the current validator set at [stats
 
 **Total Blocks**
 
-For real-time updates and information, please visit [explorer.celo.org](https://explorer.celo.org/) 
+For real-time updates and information, please visit [explorer.celo.org](https://explorer.celo.org/)
 
 **Average Block Time**
 
-Celo's average blocktime is 5 seconds. For real-time updates and information, please visit [https://explorer.celo.org/](https://explorer.celo.org/) 
+Celo's average blocktime is 5 seconds. For real-time updates and information, please visit [https://explorer.celo.org/](https://explorer.celo.org/)
 
 **Average User-Perceived Transaction Time Average Network Transaction (Gas) Fee**
 
@@ -129,12 +132,12 @@ Real-time gas fees are captured in gwei on [stats.celo.org](https://stats.celo.o
 
 **Circulating Supply**
 
-* **CELO:** Metric updated in real-time, please visit  [coinmarketcap.com/currencies/celo](https://coinmarketcap.com/currencies/celo/) 
-* **cUSD + cEUR:** Metrics updated in real-time, please visit [celoreserve.org](https://celoreserve.org/) 
+- **CELO:** Metric updated in real-time, please visit [coinmarketcap.com/currencies/celo](https://coinmarketcap.com/currencies/celo/)
+- **cUSD + cEUR:** Metrics updated in real-time, please visit [celoreserve.org](https://celoreserve.org/)
 
 :::tip
 
-For current circulating supply of cUSD and cEUR please see the section titled ‘outstanding supply’ and reference the top number in black. 
+For current circulating supply of cUSD and cEUR please see the section titled ‘outstanding supply’ and reference the top number in black.
 
 :::
 
@@ -144,6 +147,6 @@ For real-time updates, please visit [wren.co/profile/celo](https://www.wren.co/p
 
 :::tip
 
-Tons of carbon offset reflect Celo community purchases of carbon credits by way of funding the Community tree planting project with Wren. 
+Tons of carbon offset reflect Celo community purchases of carbon credits by way of funding the Community tree planting project with Wren.
 
 :::

--- a/docs/learn/celo-stack.md
+++ b/docs/learn/celo-stack.md
@@ -1,12 +1,13 @@
 ---
-title: The Celo Stack
-description: Overview of the Celo Stack including it's blockchain, core contracts, and applications. 
+title: Architecture
+description: Overview of the Celo Stack including it's blockchain, core contracts, and applications.
 ---
-# The Celo Stack
 
-Overview of the Celo Stack including it's blockchain, core contracts, and applications. 
+# Architecture
 
-___
+Overview of the Celo Stack including it's blockchain, core contracts, and applications.
+
+---
 
 ## Introduction to the Celo Stack
 
@@ -29,3 +30,31 @@ A set of smart contracts running on the Celo blockchain that comprise much of th
 Applications for end users built on the Celo Platform. The Celo Wallet app, the first of an ecosystem of applications, allows end-users to manage accounts and make payments securely and simply by taking advantage of the innovations in the Celo Protocol. Applications take the form of external mobile or backend software: they interact with the Celo blockchain to issue transactions and invoke code that forms the Celo Core Contracts’ API. Third parties can also deploy custom smart contracts that their own applications can invoke, which in turn can leverage Celo Core Contracts. Applications may use centralized cloud services to provide some of their functionality: in the case of the Celo Wallet, push notifications, and a transaction activity feed.
 
 The Celo blockchain and Celo Core Contracts together comprise the Celo Protocol.
+
+## Celo Network Topology
+
+The topology of a Celo network consists of machines running the Celo blockchain software in several distinct configurations:
+
+![](https://storage.googleapis.com/celo-website/docs/network.png)
+
+## Validators
+
+Validators gather transactions received from other nodes and execute any associated smart contracts to form new blocks, then participate in a Byzantine Fault Tolerant (BFT) consensus protocol to advance the state of the network. Since BFT protocols can scale only to a few hundred participants and can tolerate at most a third of the participants acting maliciously, a proof-of-stake mechanism admits only a limited set of nodes to this role.
+
+## Full Nodes
+
+Most machines running the Celo blockchain software are either not configured to be, or not elected as, validators. Celo nodes do not do "mining" as in Proof-of-Work networks. Their primary role is to serve requests from light clients and forward their transactions, for which they receive the fees associated with those transactions. These payments create a ‘permissionless onramp’ for individuals in the community to earn currency. Full nodes maintain at least a partial history of the blockchain by transferring new blocks between themselves and can join or leave the network at any time.
+
+## Light Clients
+
+Applications including the Celo Wallet will also run on each user's device an instance of the Celo blockchain software operating as a ‘light client’. Light clients connect to full nodes to make requests for account and transaction data and to sign and submit new transactions, but they do not receive or retain the full state of the blockchain.
+
+## Celo Wallet
+
+The Celo Wallet application is a fully unmanaged wallet that allows users to self custody their funds using their own keys and accounts. All critical features such as sending transactions and checking balances can be done in a trustless manner using the peer-to-peer light client protocol. However, the wallet does use a few centralized cloud services to improve the user experience where possible, e.g.:
+
+- **Google Play Services:** to pre-load invitations in the app
+- **Celo Wallet Notification Service:** sends device push notifications when a user receives a payment or requests for payment
+- **Celo Wallet Blockchain API:** provides a GraphQL API to query transactions on the blockchain on a per-account basis, used to implement a users' activity feed.
+
+When end-users download the Celo Wallet from, for example, the Google Play Store, users are trusting both cLabs (or the entity that has made the application available in the Play Store) and Google to deliver a correct binary, and most users would feel that relying on these centralized services to provide this additional functionality is worthwhile.

--- a/docs/learn/introduction-to-celo.md
+++ b/docs/learn/introduction-to-celo.md
@@ -5,16 +5,13 @@ slug: /introduction-to-celo
 description: Celo believes in a future where everyone can prosper.
 ---
 
-# Introduction to Celo
+# Key Concepts
 
 Crypto made for mobile.
 
-___
+---
 
 import YouTube from '@components/YouTube';
-
-Celo is a mobile-first, carbon-neutral blockchain that makes decentralized financial (DeFi) tools and services accessible to anyone with a mobile phone–bringing the powerful benefits of DeFi to the users of the 6 billion smartphones in circulation today.
-
 
 ## What is the Celo Platform?
 
@@ -31,7 +28,6 @@ CELO is a platform-native reserve and governance asset, serving as the primary a
 <YouTube videoId="PLodjpBer4M"/>
 
 [Learn more about Celo](/why-celo)
-
 
 ## What can Celo Dollars Do?
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -8,14 +8,13 @@ slug: /welcome
 import YouTube from '@components/YouTube';
 import PageRef from '@components/PageRef';
 
-
 Celo's mission is to build a financial system that creates the conditions for prosperity—for everyone.
 
-___
+---
 
 ## Crypto made for Mobile
 
-Celo is a mobile-first blockchain that makes decentralized financial (DeFi) tools and services accessible to anyone with a mobile phone. It aims to break down barriers by bringing the powerful benefits of DeFi to the users of the 6 billion smartphones in circulation today. 
+Celo is a mobile-first blockchain that makes decentralized financial (DeFi) tools and services accessible to anyone with a mobile phone. It aims to break down barriers by bringing the powerful benefits of DeFi to the users of the 6 billion smartphones in circulation today.
 
 [View Website](https://www.celo.org)
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -320,36 +320,36 @@ module.exports = {
             items: [
                 {
                     "to": "welcome",
-                    "label": "Welcome",
+                    "label": "Basics",
+                    "position": "left"
+                },
+                {
+                    "to": "celo-holder-guide/overview",
+                    "label": "Use Celo",
                     "position": "left"
                 },
                 {
                     "to": "developer-guide/overview",
-                    "label": "Developers",
+                    "label": "Develop",
                     "position": "left"
                 },
                 {
                     "to": "validator-guide/overview",
-                    "label": "Validators",
-                    "position": "left"
-                },
-                {
-                    "to": "celo-holder-guide/owners",
-                    "label": "Owners",
-                    "position": "left"
-                },
-                {
-                    "to": "developer-guide/integrations",
-                    "label": "Integrations",
+                    "label": "Validate",
                     "position": "left"
                 },
                 {
                     "to": "/community/contributing",
-                    "label": "Community",
+                    "label": "Contribute",
                     "position": "left"
                 },
                 {
-                    "to": "/blog",
+                    "to": "/blog/tags",
+                    "label": "Tutorials",
+                    "position": "left"
+                },
+                {
+                    "to": "https://medium.com/celoorg",
                     "label": "Blog",
                     "position": "right"
                 },                

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -344,7 +344,7 @@ module.exports = {
                     "position": "left"
                 },
                 {
-                    "to": "/blog/tags",
+                    "to": "/blog",
                     "label": "Tutorials",
                     "position": "left"
                 },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -497,6 +497,7 @@ module.exports = {
                     blogSidebarTitle: 'All posts',
                     blogSidebarCount: 'ALL',
                     showReadingTime: true,
+                    blogListComponent: require.resolve('./src/components/CustomBlogListPage.module.tsx'),
                     readingTime: ({content, frontMatter, defaultReadingTime}) =>
                         // allows per post reading time override in frontmatter
                         frontMatter.hide_reading_time ? undefined : defaultReadingTime({content, options: {wordsPerMinute: 300}}),

--- a/sidebars.js
+++ b/sidebars.js
@@ -325,24 +325,6 @@ const sidebars = {
             },
             {
               type: 'category',
-              label: 'Code Examples',
-              items: [
-                { type: 'doc', label: 'Introduction', id: 'developer-resources/start',},
-                { type: 'doc', label: 'Sending CELO & Stable Assets', id: 'developer-resources/walkthroughs/hellocelo',},
-                { type: 'doc', label: 'Deploy to a Local Node', id: 'developer-resources/walkthroughs/hellocontracts',},
-                { type: 'doc', label: 'Deploy to a Remote Node', id: 'developer-resources/walkthroughs/hello-contract-remote-node',},
-                'developer-resources/walkthroughs/no-code-erc20',
-                'developer-resources/walkthroughs/no-code-erc721',
-                'developer-resources/walkthroughs/web-dapp',
-                { type: 'doc', label: 'Use onchain randomness', id: 'developer-resources/walkthroughs/randomness',},
-                { type: 'doc', label: 'Valora + Wallet Connect', id: 'developer-resources/walkthroughs/valora-wc-v1',},
-                { type: 'doc', label: 'Using Keystores', id: 'developer-resources/walkthroughs/using-js-keystores',},
-                { type: 'link', label: 'Figment | Celo 101', href: 'https://learn.figment.io/protocols/celo/' },
-                { type: 'link', label: 'Dacade | Celo 101', href: 'https://dacade.org/communities/celo-development-101' }, 
-              ]
-            },
-            {
-              type: 'category',
               label: 'DAppKit',
               items: [
                 { type: 'doc', label: 'Overview', id: 'developer-resources/dappkit/index',},
@@ -354,6 +336,24 @@ const sidebars = {
             { type: 'doc', label: 'Wallet', id: 'developer-resources/testnet-wallet', },
             { type: 'doc', label: 'Development Chain', id: 'developer-resources/walkthroughs/development-chain', },
           ],
+        },
+        {
+          type: 'category',
+          label: 'Code Examples',
+          items: [
+            { type: 'doc', label: 'Introduction', id: 'developer-resources/start',},
+            { type: 'doc', label: 'Sending CELO & Stable Assets', id: 'developer-resources/walkthroughs/hellocelo',},
+            { type: 'doc', label: 'Deploy to a Local Node', id: 'developer-resources/walkthroughs/hellocontracts',},
+            { type: 'doc', label: 'Deploy to a Remote Node', id: 'developer-resources/walkthroughs/hello-contract-remote-node',},
+            'developer-resources/walkthroughs/no-code-erc20',
+            'developer-resources/walkthroughs/no-code-erc721',
+            'developer-resources/walkthroughs/web-dapp',
+            { type: 'doc', label: 'Use onchain randomness', id: 'developer-resources/walkthroughs/randomness',},
+            { type: 'doc', label: 'Valora + Wallet Connect', id: 'developer-resources/walkthroughs/valora-wc-v1',},
+            { type: 'doc', label: 'Using Keystores', id: 'developer-resources/walkthroughs/using-js-keystores',},
+            { type: 'link', label: 'Figment | Celo 101', href: 'https://learn.figment.io/protocols/celo/' },
+            { type: 'link', label: 'Dacade | Celo 101', href: 'https://dacade.org/communities/celo-development-101' }, 
+          ]
         },
         {
           type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,38 +1,73 @@
 const sidebars = {
   docs: [
-    // { type: "doc", label: "Welcome to Celo", id: "welcome",},
     { type: 'doc', label: 'Welcome to Celo', id: 'welcome', },
-    {
-      type: "category",
-      label: "Getting Started",
-      items: [
-        { type: 'doc', label: 'Introduction', id: 'learn/introduction-to-celo', },
-        { type: "doc", label: "DApp Gallery", id: "developer-resources/celo-dapp-gallery",},
+    { type: 'doc', label: 'Key Concepts', id: 'learn/introduction-to-celo', },
+    { type: 'doc', label: 'Architecture', id: 'learn/celo-stack', },
+    { type: 'doc', label: 'Whitepapers', id: 'learn/celo-whitepapers', },
+    { type: 'doc', label: 'Community', id: 'community/join-the-community', },
+    { type: "doc", label: "Glossary", id: "getting-started/glossary",},
+    { type: "doc", label: "Gallery", id: "developer-resources/celo-dapp-gallery",},
+    { type: 'doc', label: 'FAQ', id: 'faqs', },
+    // {
+    //   type: "category",
+    //   label: "Getting Started",
+    //   items: [
+    //     {
+    //       type: 'category',
+    //       label: 'Celo Basics',
+    //       items: [
+    //         { type: 'doc', label: 'Why Celo', id: 'learn/why-celo', },
+    //         { type: 'doc', label: 'Highlights', id: 'learn/celo-highlights', },
+    //         { type: 'doc', label: 'Economic Model', id: 'learn/celo-economic-model', },
+    //         { type: 'doc', label: 'Milestones', id: 'learn/celo-milestones', },
+    //         { type: 'doc', label: 'Ecosystem', id: 'learn/celo-ecosystem', },
+    //       ]
+    //     },
+    //     {
+    //       type: 'category',
+    //       label: 'Celo Platform',
+    //       items: [
+    //         { type: 'doc', label: 'Introduction', id: 'overview', },
+    //         { type: 'doc', label: 'Network Topology', id: 'learn/topology-of-a-celo-network', },
+    //         { type: 'doc', label: 'Celo Protocol', id: 'learn/celo-protocol', },
+    //       ]
+    //     }, 
+    //   ],
+    // },
+  ],
+
+  // ######################################
+  // validators 
+  // ######################################
+  validators: [
+        { type: "doc", label: "Overview", id: "validator-guide/overview",}, 
+        { type: "doc", label: "Attestation Service", id: 'validator-guide/attestation-service',},
         {
           type: 'category',
-          label: 'Celo Basics',
+          label: 'Key Management',
           items: [
-            { type: 'doc', label: 'Why Celo', id: 'learn/why-celo', },
-            { type: 'doc', label: 'Highlights', id: 'learn/celo-highlights', },
-            { type: 'doc', label: 'Whitepapers', id: 'learn/celo-whitepapers', },
-            { type: 'doc', label: 'Economic Model', id: 'learn/celo-economic-model', },
-            { type: 'doc', label: 'Milestones', id: 'learn/celo-milestones', },
-            { type: 'doc', label: 'Ecosystem', id: 'learn/celo-ecosystem', },
+            { type: "doc", label: "Summary", id: 'validator-guide/key-management/summary',},
+            { type: "doc", label: "Key Management", id: 'validator-guide/key-management/detailed',},
+            { type: "doc", label: "Key Rotation", id: 'validator-guide/key-management/key-rotation',},
           ]
         },
-        {
-          type: 'category',
-          label: 'Celo Platform',
-          items: [
-            { type: 'doc', label: 'Introduction', id: 'overview', },
-            { type: 'doc', label: 'Celo Stack', id: 'learn/celo-stack', },
-            { type: 'doc', label: 'Network Topology', id: 'learn/topology-of-a-celo-network', },
-            { type: 'doc', label: 'Celo Protocol', id: 'learn/celo-protocol', },
-          ]
-        }, 
-        // { type: "doc", label: "Celo Overview", id: "overview", },
-      ],
-    },
+        { type: 'doc', label: 'Run Secure Nodes and Services', id: 'validator-guide/securing-nodes-and-services', },
+        { type: 'doc', label: 'Monitoring', id: 'validator-guide/monitoring', },
+        { type: 'doc', label: 'DevOps Best Practices', id: 'validator-guide/devops-best-practices', },
+        { type: 'doc', label: 'Node Upgrades', id: 'validator-guide/node-upgrades', },
+        { type: 'doc', label: 'Running Proxies', id: 'validator-guide/proxy', },
+        { type: 'doc', label: 'Validator Explorer', id: 'validator-guide/validator-explorer', },
+        { type: 'doc', label: 'Voting Policy', id: 'validator-guide/celo-foundation-voting-policy',},
+        { type: 'doc', label: 'Celo Signal', id: 'validator-guide/celo-signal',},
+        { type: "doc", label: "Validator FAQ", id: "getting-started/validator-troubleshooting-faq",},
+  ],
+
+  // ######################################
+  // users 
+  // ######################################
+
+  users: [
+    { type: 'doc', label: 'Overview', id: 'celo-holder-guide/overview' },
     {
       type: "category",
       label: "Wallets",
@@ -71,6 +106,60 @@ const sidebars = {
           ]
         },
       ],
+    },
+    {
+      type: 'category',
+      label: 'Get CELO',
+      items: [   
+        { type: 'doc', label: 'Overview', id: 'celo-holder-guide/owners' },  
+        {
+          type: 'category',
+          label: 'Manage Assets',
+          items: [
+            { type: 'doc', label: 'Self-Custody CELO', id: 'celo-holder-guide/quick-start' },
+            { type: 'doc', label: 'Asset Management', id: 'celo-holder-guide/cusd' },
+            { type: 'doc', label: 'Release Gold', id: 'celo-holder-guide/release-gold' },
+            { type: 'doc', label: 'Exchange Celo Assets', id: 'celo-holder-guide/celo-exchange-bot', },
+          ]
+        },
+        {
+          type: 'category',
+          label: 'Voting',
+          items: [
+            { type: 'doc', label: 'Voting for Validators', id: 'celo-holder-guide/voting-validators', },
+            { type: 'doc', label: 'Voting on Governance', id: 'celo-holder-guide/voting-governance', },
+            { type: 'doc', label: 'Governance Cheat Sheet', id: 'celo-holder-guide/governance-cheat-sheet', },
+          ]
+        },
+        {
+          type: 'category',
+          label: 'Recovery',
+          items: [
+            { type: 'doc', label: 'Recover from ETH Address', id: 'celo-holder-guide/eth-recovery', },
+            { type: 'doc', label: 'Recover from Celo Address', id: 'celo-holder-guide/celo-recovery', },
+          ]
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Bridging',
+      items: [
+        { type: 'doc', label: 'Celo Bridges', id: 'celo-codebase/protocol/bridging/bridging-to-celo', },
+        { type: 'doc', label: 'Optics Bridge GUI', id: 'celo-codebase/protocol/bridging/optics-gui', },
+        { type: 'doc', label: 'Native Assets with Etherscan', id: 'celo-codebase/protocol/bridging/bridging-native-assets', },
+        { type: 'doc', label: 'Tokens with Etherscan', id: 'celo-codebase/protocol/bridging/bridging-tokens-with-etherscan', },
+        { type: 'doc', label: 'Migrating to Optics v2', id: 'celo-codebase/protocol/bridging/migrating-to-optics-v2', },
+        { type: 'doc', label: 'Optics Bridge FAQ', id: 'celo-codebase/protocol/bridging/optics-bridge-faq', },
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Oracles',
+      items: [
+        { type: 'doc', label: 'Celo Oracles', id: 'celo-codebase/protocol/oracles/oracles-on-celo', },
+        { type: 'doc', id: 'celo-codebase/protocol/oracles/band-protocol-how-to', },
+      ]
     },
     {
       type: 'category',
@@ -188,49 +277,6 @@ const sidebars = {
       ],
     },
     {
-      type: 'category',
-      label: 'Bridging',
-      items: [
-        { type: 'doc', label: 'Celo Bridges', id: 'celo-codebase/protocol/bridging/bridging-to-celo', },
-        { type: 'doc', label: 'Optics Bridge GUI', id: 'celo-codebase/protocol/bridging/optics-gui', },
-        { type: 'doc', label: 'Native Assets with Etherscan', id: 'celo-codebase/protocol/bridging/bridging-native-assets', },
-        { type: 'doc', label: 'Tokens with Etherscan', id: 'celo-codebase/protocol/bridging/bridging-tokens-with-etherscan', },
-        { type: 'doc', label: 'Migrating to Optics v2', id: 'celo-codebase/protocol/bridging/migrating-to-optics-v2', },
-        { type: 'doc', label: 'Optics Bridge FAQ', id: 'celo-codebase/protocol/bridging/optics-bridge-faq', },
-      ]
-    },
-    {
-      type: 'category',
-      label: 'Oracles',
-      items: [
-        { type: 'doc', label: 'Celo Oracles', id: 'celo-codebase/protocol/oracles/oracles-on-celo', },
-        { type: 'doc', id: 'celo-codebase/protocol/oracles/band-protocol-how-to', },
-      ]
-    },
-    { type: "doc", label: "Glossary", id: "getting-started/glossary",},
-    { type: 'doc', label: 'FAQ', id: 'faqs', },
-    {
-      type: 'category',
-      label: 'Resources',
-      items: [
-        { type: 'doc', label: 'Celo Onboarding', id: 'learn/celo-onboarding', },
-        { type: 'doc', label: 'Developer Onboarding', id: 'learn/developer-onboarding', },
-        {
-          type: 'category',
-          label: 'Quick Guides',
-          items: [
-            { type: 'doc', label: 'Celo', id: 'learn/celo-summary', },
-            { type: 'doc', label: 'Celo Protocol', id: 'learn/celo-protocol-summary', },
-            { type: 'doc', label: 'Valora', id: 'learn/valora-summary', },
-            { type: 'doc', label: 'CELO', id: 'learn/CELO-coin-summary', },
-            { type: 'doc', label: 'Celo Stablecoins', id: 'learn/platform-native-stablecoins-summary', },
-          ]
-        },
-        { type: 'doc', label: 'Figment Learn', id: 'learn/figment-learn', },
-        { type: 'doc', label: 'Celo Resources', id: 'learn/celo-resources', },
-      ]
-    },
-    {
       type: "category",
       label: "Command Line",
       items: [
@@ -245,11 +291,11 @@ const sidebars = {
   // Developers 
   // ######################################
   developers: [
-        { type: 'doc', label: 'Developers', id: 'developer-resources/overview', },
+        { type: 'doc', label: 'Overview', id: 'developer-resources/overview', },
         // { type: 'doc', label: 'Basics', id: 'developer-resources/developer-basics',}, 
         {
           type: 'category',
-          label: 'Build on Celo',
+          label: 'Local Environment',
           items: [
             { type: 'doc', label: 'Start Building', id: 'developer-resources/deploy-dapp',},
             'developer-resources/deploy-remix',
@@ -259,36 +305,10 @@ const sidebars = {
           ]
         },       
         {
-          type: 'category',
-          label: 'Local Environment',
-          items: [
-            { type: 'doc', label: 'Using Mac', id: 'developer-resources/using-mac',},
-            { type: 'doc', label: 'Using Windows', id: 'developer-resources/develop-on-windows',},
-          ]
-        },
-        {
-          type: 'category',
-          label: 'Code Examples',
-          items: [
-            { type: 'doc', label: 'Introduction', id: 'developer-resources/start',},
-            { type: 'doc', label: 'Sending CELO & Stable Assets', id: 'developer-resources/walkthroughs/hellocelo',},
-            { type: 'doc', label: 'Deploy to a Local Node', id: 'developer-resources/walkthroughs/hellocontracts',},
-            { type: 'doc', label: 'Deploy to a Remote Node', id: 'developer-resources/walkthroughs/hello-contract-remote-node',},
-            'developer-resources/walkthroughs/no-code-erc20',
-            'developer-resources/walkthroughs/no-code-erc721',
-            'developer-resources/walkthroughs/web-dapp',
-            { type: 'doc', label: 'Use onchain randomness', id: 'developer-resources/walkthroughs/randomness',},
-            { type: 'doc', label: 'Valora + Wallet Connect', id: 'developer-resources/walkthroughs/valora-wc-v1',},
-            { type: 'doc', label: 'Using Keystores', id: 'developer-resources/walkthroughs/using-js-keystores',},
-            { type: 'link', label: 'Figment | Celo 101', href: 'https://learn.figment.io/protocols/celo/' },
-            { type: 'link', label: 'Dacade | Celo 101', href: 'https://dacade.org/communities/celo-development-101' }, 
-          ]
-        },
-        {
           type: "category",
           label: "Developer Tools",
           items: [
-            { type: 'doc', label: 'Developer Tools', id: 'learn/developer-tools', },
+            { type: 'doc', label: 'Overview', id: 'learn/developer-tools', },
             { type: 'doc', label: 'EVM Tools', id: 'learn/evm-compatible-tooling', },
             {
               type: 'category',
@@ -305,6 +325,24 @@ const sidebars = {
             },
             {
               type: 'category',
+              label: 'Code Examples',
+              items: [
+                { type: 'doc', label: 'Introduction', id: 'developer-resources/start',},
+                { type: 'doc', label: 'Sending CELO & Stable Assets', id: 'developer-resources/walkthroughs/hellocelo',},
+                { type: 'doc', label: 'Deploy to a Local Node', id: 'developer-resources/walkthroughs/hellocontracts',},
+                { type: 'doc', label: 'Deploy to a Remote Node', id: 'developer-resources/walkthroughs/hello-contract-remote-node',},
+                'developer-resources/walkthroughs/no-code-erc20',
+                'developer-resources/walkthroughs/no-code-erc721',
+                'developer-resources/walkthroughs/web-dapp',
+                { type: 'doc', label: 'Use onchain randomness', id: 'developer-resources/walkthroughs/randomness',},
+                { type: 'doc', label: 'Valora + Wallet Connect', id: 'developer-resources/walkthroughs/valora-wc-v1',},
+                { type: 'doc', label: 'Using Keystores', id: 'developer-resources/walkthroughs/using-js-keystores',},
+                { type: 'link', label: 'Figment | Celo 101', href: 'https://learn.figment.io/protocols/celo/' },
+                { type: 'link', label: 'Dacade | Celo 101', href: 'https://dacade.org/communities/celo-development-101' }, 
+              ]
+            },
+            {
+              type: 'category',
               label: 'DAppKit',
               items: [
                 { type: 'doc', label: 'Overview', id: 'developer-resources/dappkit/index',},
@@ -313,100 +351,50 @@ const sidebars = {
               ]
             },
             { type: 'doc', label: 'Forno', id: 'developer-resources/forno/index',},
+            { type: 'doc', label: 'Wallet', id: 'developer-resources/testnet-wallet', },
+            { type: 'doc', label: 'Development Chain', id: 'developer-resources/walkthroughs/development-chain', },
           ],
         },
         {
           type: 'category',
-          label: 'Mobile Development',
+          label: 'Build on Mobile',
           items: [
             { type: 'doc', label: 'Celo Wallet', id: 'celo-codebase/wallet/index', },
             { type: 'doc', label: 'Running the wallet locally', id: 'celo-codebase/wallet/intro', },
             { type: "doc", label: "Using the Wallet", id: "getting-started/using-the-wallet",},
           ]
         },
-        { type: 'doc', label: 'Testnet Wallet', id: 'developer-resources/testnet-wallet', },
-        { type: 'doc', label: 'Development Chain', id: 'developer-resources/walkthroughs/development-chain', },
-        { type: 'doc', label: 'Ethereum Developers', id: 'developer-resources/celo-for-eth-devs', },
+        {
+          type: 'category',
+          label: 'Integrate with Celo',
+          items: [
+            { type: 'doc', label: 'Integrations', id: 'developer-resources/integrations/integrations' },
+            { type: 'doc', label: 'General', id: 'developer-resources/integrations/general' },
+            { type: 'doc', label: 'Checklist', id: 'developer-resources/integrations/checklist' },
+            { type: 'doc', label: 'Custody', id: 'developer-resources/integrations/custody' },
+            { type: 'doc', label: 'Listings', id: 'developer-resources/integrations/listings' },
+            { type: 'doc', label: 'Cloud HSM', id: 'developer-resources/integrations/cloud-hsm' },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'From another platform?',
+          items: [
+              { type: 'doc', label: 'Ethereum Developers', id: 'developer-resources/celo-for-eth-devs', },
+          ],
+        },
         // TODO: This link will need to be changed when we move all the SDK type docs
         { type: 'link', label: 'SDK Code Reference', href: 'https://celo-sdk-docs.readthedocs.io/' },
   ],
-  // ######################################
-  // Validators 
-  // ######################################
-  validators: [ 
-    { type: "doc", label: "Validators", id: "validator-guide/overview",}, 
-    { type: "doc", label: "Attestation Service", id: 'validator-guide/attestation-service',},
-    {
-      type: 'category',
-      label: 'Key Management',
-      items: [
-        { type: "doc", label: "Summary", id: 'validator-guide/key-management/summary',},
-        { type: "doc", label: "Key Management", id: 'validator-guide/key-management/detailed',},
-        { type: "doc", label: "Key Rotation", id: 'validator-guide/key-management/key-rotation',},
-      ]
-    },
-    { type: 'doc', label: 'Run Secure Nodes and Services', id: 'validator-guide/securing-nodes-and-services', },
-    { type: 'doc', label: 'Monitoring', id: 'validator-guide/monitoring', },
-    { type: 'doc', label: 'DevOps Best Practices', id: 'validator-guide/devops-best-practices', },
-    { type: 'doc', label: 'Node Upgrades', id: 'validator-guide/node-upgrades', },
-    { type: 'doc', label: 'Running Proxies', id: 'validator-guide/proxy', },
-    { type: 'doc', label: 'Validator Explorer', id: 'validator-guide/validator-explorer', },
-    { type: 'doc', label: 'Voting Policy', id: 'validator-guide/celo-foundation-voting-policy',},
-    { type: 'doc', label: 'Celo Signal', id: 'validator-guide/celo-signal',},
-    { type: "doc", label: "Validator FAQ", id: "getting-started/validator-troubleshooting-faq",},
-  ],
-  // ######################################
-  // Owners 
-  // ######################################
-  own: [  
-    { type: 'doc', label: 'Owners', id: 'celo-holder-guide/owners' },
-    {
-      type: 'category',
-      label: 'Manage Assets',
-      items: [
-        { type: 'doc', label: 'Self-Custody CELO', id: 'celo-holder-guide/quick-start' },
-        { type: 'doc', label: 'Asset Management', id: 'celo-holder-guide/cusd' },
-        { type: 'doc', label: 'Release Gold', id: 'celo-holder-guide/release-gold' },
-        { type: 'doc', label: 'Exchange Celo Assets', id: 'celo-holder-guide/celo-exchange-bot', },
-      ]
-    },
-    {
-      type: 'category',
-      label: 'Voting',
-      items: [
-        { type: 'doc', label: 'Voting for Validators', id: 'celo-holder-guide/voting-validators', },
-        { type: 'doc', label: 'Voting on Governance', id: 'celo-holder-guide/voting-governance', },
-        { type: 'doc', label: 'Governance Cheat Sheet', id: 'celo-holder-guide/governance-cheat-sheet', },
-      ]
-    },
-    {
-      type: 'category',
-      label: 'Recovery',
-      items: [
-        { type: 'doc', label: 'Recover from ETH Address', id: 'celo-holder-guide/eth-recovery', },
-        { type: 'doc', label: 'Recover from Celo Address', id: 'celo-holder-guide/celo-recovery', },
-      ]
-    },
-  ], 
-    // ######################################
-  // Integration 
-  // ######################################
-  integrate: [  
-    { type: 'doc', label: 'Integrations', id: 'developer-resources/integrations/integrations' },
-    { type: 'doc', label: 'General', id: 'developer-resources/integrations/general' },
-    { type: 'doc', label: 'Checklist', id: 'developer-resources/integrations/checklist' },
-    { type: 'doc', label: 'Custody', id: 'developer-resources/integrations/custody' },
-    { type: 'doc', label: 'Listings', id: 'developer-resources/integrations/listings' },
-    { type: 'doc', label: 'Cloud HSM', id: 'developer-resources/integrations/cloud-hsm' },
-  ], 
+
   // ######################################
   // Contributors 
   // ######################################
   contributors: [ 
-    { type: 'doc', label: 'Community', id: 'community/contributing', },
+    { type: 'doc', label: 'Contribute', id: 'community/contributing', },
     {
       type: 'category',
-      label: 'Contributors',
+      label: 'Ambassadors',
       items: [
         { type: 'doc', label: 'Guidelines', id: 'community/guidelines', },
         { type: 'doc', label: 'Code', id: 'community/code-contributors' },
@@ -437,7 +425,27 @@ const sidebars = {
         { type: 'doc', label: 'Mainnet Disclaimer', id: 'important-information/mainnet-network-disclaimer', },
       ]
     },
-    { type: 'doc', label: 'Join the Community', id: 'community/join-the-community', },
+    {
+      type: 'category',
+      label: 'Resources',
+      items: [
+        { type: 'doc', label: 'Celo Onboarding', id: 'learn/celo-onboarding', },
+        { type: 'doc', label: 'Developer Onboarding', id: 'learn/developer-onboarding', },
+        {
+          type: 'category',
+          label: 'Quick Guides',
+          items: [
+            { type: 'doc', label: 'Celo', id: 'learn/celo-summary', },
+            { type: 'doc', label: 'Celo Protocol', id: 'learn/celo-protocol-summary', },
+            { type: 'doc', label: 'Valora', id: 'learn/valora-summary', },
+            { type: 'doc', label: 'CELO', id: 'learn/CELO-coin-summary', },
+            { type: 'doc', label: 'Celo Stablecoins', id: 'learn/platform-native-stablecoins-summary', },
+          ]
+        },
+        { type: 'doc', label: 'Figment Learn', id: 'learn/figment-learn', },
+        { type: 'doc', label: 'Celo Resources', id: 'learn/celo-resources', },
+      ]
+    },
   ],  
 };
 module.exports = sidebars;

--- a/src/components/CustomBlogListPage.module.tsx
+++ b/src/components/CustomBlogListPage.module.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ import React from 'react';
+
+ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+ import BlogLayout from '@theme/BlogLayout';
+ import BlogPostItem from '@theme/BlogPostItem';
+ import BlogListPaginator from '@theme/BlogListPaginator';
+ import type {Props} from '@theme/BlogListPage';
+ import {ThemeClassNames} from '@docusaurus/theme-common';
+ 
+ function BlogListPage(props: Props): JSX.Element {
+   const {metadata, items, sidebar} = props;
+   const {
+     siteConfig: {title: siteTitle},
+   } = useDocusaurusContext();
+   const {blogDescription, blogTitle, permalink} = metadata;
+   const isBlogOnlyMode = permalink === '/';
+   const title = isBlogOnlyMode ? siteTitle : blogTitle;
+ 
+   return (
+     <BlogLayout
+       title={title}
+       description={blogDescription}
+       wrapperClassName={ThemeClassNames.wrapper.blogPages}
+       pageClassName={ThemeClassNames.page.blogListPage}
+       searchMetadata={{
+         // assign unique search tag to exclude this page from search results!
+         tag: 'blog_posts_list',
+       }}
+       sidebar={sidebar}>
+       <a href="/blog/tags">Filter posts by tag</a>
+       {items.map(({content: BlogPostContent}) => (
+         <BlogPostItem
+           key={BlogPostContent.metadata.permalink}
+           frontMatter={BlogPostContent.frontMatter}
+           assets={BlogPostContent.assets}
+           metadata={BlogPostContent.metadata}
+           truncated={BlogPostContent.metadata.truncated}>
+           <BlogPostContent />
+         </BlogPostItem>
+       ))}
+       <BlogListPaginator metadata={metadata} />
+     </BlogLayout>
+   );
+ }
+ 
+ export default BlogListPage;
+ 

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -61,7 +61,7 @@ const FeatureList = [
     ),
     link: (
       // <a href="https://deploy-preview-154--celo-docs.netlify.app/learn/celo-overview">Learn Celo</a>
-      <a href="/blog/tags/">Learn more with Celo</a>
+      <a href="/blog/">Learn more with Celo</a>
     ),
   },
 ];

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -4,7 +4,27 @@ import styles from './HomepageFeatures.module.css';
 
 const FeatureList = [
   {
-    title: 'Developers',
+    title: 'Learn the basics',
+    // Svg: require('../../static/img/homepage/1.svg').default,
+    description: (
+      <>Join the mission to build a financial system that creates the conditions for prosperity—for everyone.</>
+    ),
+    link: (
+      <a href="/welcome">Get started with Celo</a>
+    ),
+  },
+  {
+    title: 'Use Celo',
+    // Svg: require('../../static/img/homepage/1.svg').default,
+    description: (
+      <>Start sending, spending, and earning crypto from your mobile phone.</>
+    ),
+    link: (
+      <a href="/celo-holder-guide/overview">Use the Celo network</a>
+    ),
+  },
+  {
+    title: 'Become a developer',
     // Svg: require('../../static/img/homepage/1.svg').default,
     description: (
       <>Build, deploy, and manage applications on the Celo network.</>
@@ -14,37 +34,17 @@ const FeatureList = [
     ),
   },
   {
-    title: 'Validators',
+    title: 'Secure the network',
     // Svg: require('../../static/img/homepage/1.svg').default,
     description: (
       <>Setup Celo nodes to maintain the network and earn rewards.</>
     ),
     link: (
-      <a href="/validator-guide/overview">Run a Node</a>
+      <a href="/validator-guide/overview">Run a node</a>
     ),
   },
   {
-    title: 'Owners',
-    // Svg: require('../../static/img/homepage/1.svg').default,
-    description: (
-      <>Start sending, spending, and earning crypto from your mobile phone.</>
-    ),
-    link: (
-      <a href="/celo-holder-guide/owners">Get CELO</a>
-    ),
-  },
-  {
-    title: 'Integrations',
-    // Svg: require('../../static/img/homepage/1.svg').default,
-    description: (
-      <>Integrate your application, service, or exchange with the Celo network.</>
-    ),
-    link: (
-      <a href="/developer-guide/integrations">Integrate with Celo</a>
-    ),
-  },
-  {
-    title: 'Contributors',
+    title: 'Join the community',
     // Svg: require('../../static/img/homepage/1.svg').default,
     description: (
       <>Join a community of developers, designers, dreamers, and doers.</>
@@ -54,14 +54,14 @@ const FeatureList = [
     ),
   },
   {
-    title: 'Additional Resources',
+    title: 'Find more tutorials',
     // Svg: require('../../static/img/homepage/1.svg').default,
     description: (
       <>Gain the skills you need to get the most from the Celo platform.</>
     ),
     link: (
       // <a href="https://deploy-preview-154--celo-docs.netlify.app/learn/celo-overview">Learn Celo</a>
-      <a href="/learn/celo-onboarding">Find Celo Resources</a>
+      <a href="/blog/tags/">Learn more with Celo</a>
     ),
   },
 ];


### PR DESCRIPTION
Reorganized some top level nav.

- Broke apart the Welcome section into Basics and Use Celo. Welcome was turning into a catch-all for topics instead of an intro.
- Linked blog to Celo Medium and turned original blog link into Tutorials section. Thinking we could pull tutorials from other sections into here to clean things up a bit. 
- Brought Integration into Develop section. Wasn't much material here.