### PR TITLE
Mini PR: Comments out two sections that are not up-to-date in the identity docs

### DIFF
--- a/docs/celo-codebase/protocol/identity/index.md
+++ b/docs/celo-codebase/protocol/identity/index.md
@@ -40,7 +40,9 @@ To protect user privacy by preventing mass harvesting of phone numbers, the Celo
 
 The attestation service is a simple Node.js service that validators run to send signed messages for attestations. It can be configured with SMS providers, as different providers have different characteristics like reliability, trustworthiness and performance in different regions. The attestation service currently supports [Twilio](https://www.twilio.com) and [Nexmo](https://nexmo.com). Celo should widen the number of supported providers over time.
 
-We have been experimenting with a SMS provider that we would like community feedback on. Instead of sending the SMS via conventional providers like Twilio, users of a `Rewards Mobile App` could register themselves with a `Verification Pool` and be made responsible for sending those text messages. It would allow users with cheap or leftover SMS capacity from their cell phone plan to effectively acquire a share of the attestation request fees. It would represent a unique on-ramp for users who do not have access to classic on-ramps like exchanges. Validators could configure their attestation service to use such a SMS provider which could in theory provide better inclusion and performance.
+<!--
+ We have been experimenting with a SMS provider that we would like community feedback on. Instead of sending the SMS via conventional providers like Twilio, users of a `Rewards Mobile App` could register themselves with a `Verification Pool` and be made responsible for sending those text messages. It would allow users with cheap or leftover SMS capacity from their cell phone plan to effectively acquire a share of the attestation request fees. It would represent a unique on-ramp for users who do not have access to classic on-ramps like exchanges. Validators could configure their attestation service to use such a SMS provider which could in theory provide better inclusion and performance. 
+ -->
 
 ### Future improvements to privacy
 

--- a/docs/celo-codebase/protocol/identity/privacy-research.md
+++ b/docs/celo-codebase/protocol/identity/privacy-research.md
@@ -6,9 +6,9 @@ Celo is committed to meet the privacy needs of its users. This section describes
 
 One downside to this identity protocol is that knowledge of a phone number can let anyone quickly determine the balance of the associated wallet, which of course may be unacceptable for many use cases. For these circumstances, the contract allows users to use the `Attestations` contract in privacy mode. In this mode, the user does not map their phone number to their wallet address, but to an account that is not meant to be the recipient of transfers. Through a registered encryption key on the user’s account on the contract, schemes can be derived to allow users to selectively reveal their true wallet addresses to authorized participants.
 
-### Transaction and Balance Privacy
+<!-- ### Transaction and Balance Privacy
 
 As with most public blockchains \(e.g. Bitcoin, Ethereum\), transactions and smart contracts calls on Celo are public for everyone to see. This means that if a user wants to map the hash of their phone number to their wallet address, people with knowledge of that user's phone number will be able to see their transactions and balances.
 
-To address this issue, the cLabs team, [Matterlabs](https://matterlabs.dev) and other esteemed zk-SNARK cryptographers and Celo community members are working to create a framework that makes it easy to create gas-efficient tokens that offer Zcash-like privacy, using a shared anonymity pool. Such an implementation could allow wallets to use the default identity mode easily without the risk that someone with your phone number could see your balance and transaction history.
+To address this issue, the cLabs team, [Matterlabs](https://matterlabs.dev) and other esteemed zk-SNARK cryptographers and Celo community members are working to create a framework that makes it easy to create gas-efficient tokens that offer Zcash-like privacy, using a shared anonymity pool. Such an implementation could allow wallets to use the default identity mode easily without the risk that someone with your phone number could see your balance and transaction history. -->
 


### PR DESCRIPTION
A mini PR that comments out two sections that are not up-to-date in the identity docs.

I'm removing those paragraphs to avoid confusion, with people that might visit the docs at Celo Connect.

Changes includes: 
- commenting out a paragraph on piloting a "Rewards Mobile App" (this is not a current pilot and hasn't been for a while)
- commenting out a paragraph on working with [Matterlabs](https://matterlabs.dev/) (website down) to create Zcash-like privacy, using a shared anonymity pool.