### PR TITLE
Minor updates to Attestation Service documentation

### DIFF
--- a/docs/validator-guide/attestation-service.md
+++ b/docs/validator-guide/attestation-service.md
@@ -15,7 +15,6 @@ Please check the updated provider guidance to make sure your Attestation Service
 
 :::
 
-
 :::tip
 
 Celo Validators are strongly encouraged to operate an [Attestation Service](https://github.com/celo-org/celo-monorepo/tree/master/packages/attestation-service) instance. If you are a recipient of or considering applying to receive [votes from the Celo Foundation](/validator-guide/celo-foundation-voting-policy.md), running a reliable Attestation Service is a requirement for eligibility.
@@ -28,7 +27,7 @@ The Attestation Service is part of the [Celo identity protocol](/celo-codebase/p
 
 ![](https://storage.googleapis.com/celo-website/docs/attestations-flow.jpg)
 
-Validators receive a fee (set by [on-chain governance](/celo-holder-guide/voting-governance.md), currently 0.05 cUSD) for every attestation that they process and that is then successfully redeemed on-chain by the user. In a future release, validators will be able claim and withdraw this fee.
+Validators receive a fee (set by [on-chain governance](/celo-holder-guide/voting-governance.md), currently 0.05 cUSD) for every attestation that they process and that is then successfully redeemed on-chain by the user. Validators can claim and withdraw this fee using: [`celocli identity:withdraw-attestation-rewards`](https://docs.celo.org/command-line-interface/identity#celocli-identitywithdraw-attestation-rewards).
 
 ## Outline
 

--- a/docs/validator-guide/attestation-service.md
+++ b/docs/validator-guide/attestation-service.md
@@ -41,6 +41,10 @@ This guide steps you through setting up an Attestation Service:
 - Configure and publish validator metadata so that clients can find your attestation service
 - Configure monitoring for the attestation service and the full node (if applicable)
 
+:::tip
+If you have any questions or feedback after reading the documentation, please feel free to share them with us on GitHub: [celo-org > identity > Discussions](https://github.com/celo-org/identity/discussions/categories/help-q-a). We will happily get back to you and 
+:::
+
 ## Recent releases
 
 - [Attestation Service v1.5.0](https://github.com/celo-org/celo-monorepo/releases/tag/attestation-service-v1.5.0) (latest production release)


### PR DESCRIPTION
- [Adds CLI command to help operators withdraw attestation fees.](https://github.com/celo-org/docs/pull/389/commits/6caa82c3904b29792d33773a1ef2b961be17ccc7)
- [Adds link to Gitub Discussions for questions and feedback.](https://github.com/celo-org/docs/pull/389/commits/c6ab3057a19be173bd68dd08b9d8d84b887f193a)
- Confirmed that validator feedback below is addressed in documentation
  - https://github.com/celo-org/identity/discussions/27