### PR TITLE
update validator specs, add a section for proxy or full node

### DIFF
--- a/docs/network/mainnet/run-validator.md
+++ b/docs/network/mainnet/run-validator.md
@@ -50,6 +50,15 @@ The recommended Celo Validator setup involves continually running three instance
 
 Celo is a proof-of-stake network, which has different hardware requirements than a Proof of Work network. proof-of-stake consensus is less CPU intensive, but is more sensitive to network connectivity and latency. Below is a list of standard requirements for running Validator and Proxy nodes on the Celo Network:
 
+#### Validator node
+
+- Memory: 16 GB RAM
+- CPU: Quad core 3GHz (64-bit)
+- Disk: 512 GB of SSD storage, plus a secondary HDD desirable
+- Network: At least 1 GB input/output Ethernet with a fiber Internet connection, ideally redundant connections and HA switches
+
+#### Proxy or full node
+
 - Memory: 8 GB RAM
 - CPU: Quad core 3GHz (64-bit)
 - Disk: 256 GB of SSD storage, plus a secondary HDD desirable

--- a/docs/network/mainnet/run-validator.md
+++ b/docs/network/mainnet/run-validator.md
@@ -53,11 +53,11 @@ Celo is a proof-of-stake network, which has different hardware requirements than
 #### Validator node
 
 - Memory: 16 GB RAM
-- CPU: Quad core 3GHz (64-bit)
+- CPU: 4 core / 8 thread 64-bit CPU with 3ghz on modern CPU architecture newer than 2018 Intel Cascade Lake or Ryzen 3000 series or newer with a Geekbench 5 Single Threaded score of >1000 and Multi Threaded score of > 4000
 - Disk: 512 GB of SSD storage, plus a secondary HDD desirable
 - Network: At least 1 GB input/output Ethernet with a fiber Internet connection, ideally redundant connections and HA switches
 
-#### Proxy or full node
+#### Proxy or Full node
 
 - Memory: 8 GB RAM
 - CPU: Quad core 3GHz (64-bit)


### PR DESCRIPTION
I've added two sections one for validator nodes, and one for proxy/full nodes.

The intention here is to inform potential node operators to properly size their estimates.