### PR TITLE
Remove ReleaseGold ERC20 warning

### DIFF
--- a/docs/holder/manage/release-gold.md
+++ b/docs/holder/manage/release-gold.md
@@ -17,11 +17,6 @@ The intent of the `ReleaseGold` contract is to allow beneficiaries to participat
 
 Increasing the volume of CELO that can be used in Celo’s Proof of Stake consensus promotes network security and even greater decentralization. See below for details on specific features of the `ReleaseGold` contract, as well as how they are implemented. The [source code](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/ReleaseGold.sol) includes documentation, and technical readers are encouraged to find further details there.
 
-:::warning
-
-Please do not send any ERC20 token other han CELO or cUSD to a Release Gold contract, as it will not be able to be transfered out of the contract per [source code](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/ReleaseGold.sol#L164).
-
-:::
 
 ### Example
 


### PR DESCRIPTION
As we have added `genericTransfer`, this warning has been outdated, just remove it

https://github.com/celo-org/celo-monorepo/commit/cf84a7ddb4491b86f6ee506d95a90a992b8a559c