### PR TITLE
Update Hosted Nodes documentation

### DIFF
--- a/docs/network/node/run-hosted.md
+++ b/docs/network/node/run-hosted.md
@@ -31,18 +31,6 @@ Currently cLabs provides the following machine images:
 
 Please note that the time taken to sync a full node could be significant.
 
-## Amazon Web Services
-
-To get started with a Celo blockchain node on AWS, ensure you're in the North Virginia region (us-east-1). You'll need to navigate to the AMIs tab of the EC2 page. From there you can change your search to only include `Public images` and enter `celo-`.
-
-:::info
-
-The cLabs AWS owner ID is `243983831780`, if you're new to Celo or cloud providers, ensure the `Owner` of an AMI you launch matches `243983831780`.
-
-:::
-
-For more information if you're not familiar with launching EC2 instances from machine images, please check the excellent [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html).
-
 ## Google Cloud Platform
 
 GCP by default won't display public machine images when you search for them in your console. This means you'll need to go via the API or [gcloud](https://cloud.google.com/sdk/gcloud) command line to launch a node.
@@ -50,7 +38,7 @@ GCP by default won't display public machine images when you search for them in y
 Depending on the type of node you'd like to launch (see the above list), the `gcloud` command to use may look a bit like this:
 
 ```bash
-gcloud compute instances create <INSTANCE_NAME> --image <IMAGE_NAME> --image-project celo-testnet --project <YOUR_GCP_PROJECT>
+gcloud compute instances create <INSTANCE_NAME> --image <IMAGE_NAME> --image-project devopsre --project <YOUR_GCP_PROJECT>
 ```
 
 For more information please check the excellent [GCP documentation](https://cloud.google.com/compute/docs/images) on how to launch a compute instance from a public image.

--- a/docs/network/node/run-hosted.md
+++ b/docs/network/node/run-hosted.md
@@ -41,4 +41,17 @@ Depending on the type of node you'd like to launch (see the above list), the `gc
 gcloud compute instances create <INSTANCE_NAME> --image <IMAGE_NAME> --image-project devopsre --project <YOUR_GCP_PROJECT>
 ```
 
+If you are running a image with `full` syncmode, please increase the disk size and instance type, and optionally use a `SSD` disk:
+
+```bash
+--boot-disk-size 250 --boot-disk-type pd-ssd --machine-type=n2-standard-4 
+```
+
+For full sync mode, it will take several days to sync the whole chain. You can check the status running the next command:
+
+```bash
+container_name=celo-full-node
+docker exec -it $container_name geth attach --exec 'eth.syncing'
+```
+
 For more information please check the excellent [GCP documentation](https://cloud.google.com/compute/docs/images) on how to launch a compute instance from a public image.


### PR DESCRIPTION
Updates for the `Hosted Nodes` documentation.
Changes:

- Delete AWS documentation until images are regenerated using latest base images and fixed scripts (and we validate everything works)
- Updated gcp images
- Added reference to disk and instance customization