### PR TITLE
Adding temporal SocialConnect link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -800,6 +800,11 @@ const sidebars = {
               label: "Overview",
               id: "protocol/identity/index",
             },
+            {
+              type: "link",
+              label: "Social Connect",
+              href: "https://github.com/celo-org/identity",
+            },
             "protocol/identity/metadata",
             "protocol/identity/smart-contract-accounts",
             "protocol/identity/encrypted-cloud-backup",

--- a/static/_redirects
+++ b/static/_redirects
@@ -363,3 +363,4 @@
 /blog/tutorials/docs.celo.org /blog
 /blog/tutorials/devrel@celo.org /blog
 /developer/walletconnect /wallet
+/protocol/socialconnect https://github.com/celo-org/identity

--- a/static/_redirects
+++ b/static/_redirects
@@ -363,4 +363,4 @@
 /blog/tutorials/docs.celo.org /blog
 /blog/tutorials/devrel@celo.org /blog
 /developer/walletconnect /wallet
-/protocol/socialconnect https://github.com/celo-org/identity
+/protocol/socialconnect https://github.com/celo-org/SocialConnect


### PR DESCRIPTION
Updates:

- adding a link to identity documentation in the sidebar
- adding redirect from /protocol/socialconnect to readme SocialConnect repo