### PR TITLE
Fix Links

### DIFF
--- a/blog/01-13-2023-how-to-mint-your-erc1155-nft-on-celo/how_to_mint_your_erc1155_nft_on_celo.md
+++ b/blog/01-13-2023-how-to-mint-your-erc1155-nft-on-celo/how_to_mint_your_erc1155_nft_on_celo.md
@@ -36,7 +36,7 @@ To follow this tutorial you should have the following:
 
 * [**Celo Wallet Extension**](https://docs.celo.org/wallet): This tutorial will require you to have an account on an installed celo wallet extension, or if you’re using another wallet like metamask, you should have the celo alfajores network added. Here is a link to guide you on how to add the alfajores testnet to your custom wallet.
 
-* [**Faucets**](https://celo.org/developers/faucet): You should also have your wallet funded with Celo test funds. Here is a link to request celo faucets.
+* [**Faucets**](https://faucet.celo.org): You should also have your wallet funded with Celo test funds. Here is a link to request celo faucets.
 
 * [**Node & node package management**](https://nodejs.org/en/download/) `npm` or `yarn`: This tutorial will require you to use a preinstalled node package manager, `yarn`. You should also know about working with any package manager: `npm` or `yarn`.
 

--- a/blog/01-23-2023-How-to-Build-and-Deploy-Factory-Contracts-on-Celo-Blockchain/Como-construir-e-realizar-deploy-de-contratos-Factory-no-blockchain-Celo.md
+++ b/blog/01-23-2023-How-to-Build-and-Deploy-Factory-Contracts-on-Celo-Blockchain/Como-construir-e-realizar-deploy-de-contratos-Factory-no-blockchain-Celo.md
@@ -27,7 +27,7 @@ Neste video mostraremos como você pode realizar um deploy re um smart contract 
 Para este tutorial não é necessário conhecimento prévio. As ferramentas utilizadas serão:
 
 - Remix: [Remix](https://remix.ethereum.org/) é uma Integrated Development Environment (IDE) para desenvolvimento de smart contracts na blockchain Ethereum. Ele fornece uma plataforma fácil de usar para escrever, testar e depurar smart contracts escritos na linguagem Solidity. Além disso, a IDE Remix também fornece ferramentas para simular e executar smart contracts em diferentes ambientes de rede, incluindo a rede principal Ethereum e redes de teste. Ele é uma ferramenta popular entre desenvolvedores de smart contracts, pois oferece recursos avançados para facilitar o desenvolvimento e teste de contratos inteligentes.
-- Faucet: [Faucet](https://celo.org/developers/faucet) é utilizada para adicionar fundos a sua conta de teste na rede Alfajores.
+- Faucet: [Faucet](https://faucet.celo.org) é utilizada para adicionar fundos a sua conta de teste na rede Alfajores.
 - Alfajores: É a rede de teste da Celo que utilizaremos para demonstração a implantação de um contrato inteligente e também realizar transações dos ativos.
 
 ## Requisitos

--- a/blog/03-04-22-celo-composer/easily-build-full-stack-mobile-dapps-on-celo.md
+++ b/blog/03-04-22-celo-composer/easily-build-full-stack-mobile-dapps-on-celo.md
@@ -140,7 +140,7 @@ Copy your `PRIVATE_KEY` and testnet account address into a place you can easily 
 
 ![image](images/9.png)
 
-Copy the testnet `account address`, paste it into the [Celo Testnet Faucet](https://celo.org/developers/faucet) and select Get Started to transfer funds into your testnet account.
+Copy the testnet `account address`, paste it into the [Celo Testnet Faucet](https://faucet.celo.org) and select Get Started to transfer funds into your testnet account.
 
 ![image](images/10.png)
 

--- a/blog/05-10-22-airdropping/a-boilerplate-guide-to-airdropping-on-celo.md
+++ b/blog/05-10-22-airdropping/a-boilerplate-guide-to-airdropping-on-celo.md
@@ -34,7 +34,7 @@ So, want to learn how to build and deploy an Airdrop contract on the worlds only
 - ✅ **Step 6:** Fund the contract
 - ✅ **Step 7:** Claim the airdrop
 
-By the end of this post, you’ll be able to deploy an Airdrop contract to Alfajores (Celo’s testnet), fund the contract using the [Alfajores faucet](https://celo.org/developers/faucet), and claim the ERC20 tokens using the [web3 SDK](https://web3js.readthedocs.io/en/v1.7.3/).
+By the end of this post, you’ll be able to deploy an Airdrop contract to Alfajores (Celo’s testnet), fund the contract using the [Alfajores faucet](https://faucet.celo.org), and claim the ERC20 tokens using the [web3 SDK](https://web3js.readthedocs.io/en/v1.7.3/).
 
 :::tip
 
@@ -86,7 +86,7 @@ In the context of this tutorial, using a Merkle tree allows us to verify a user 
 
 ## ✅ Step 1: Create your account
 
-Fund your Celo address using the [Alfajores faucet](https://celo.org/developers/faucet) (to generate a new key pair, run node `tutorial/createAccount.js` from the root directory)
+Fund your Celo address using the [Alfajores faucet](https://faucet.celo.org) (to generate a new key pair, run node `tutorial/createAccount.js` from the root directory)
 
 Afterwords create the `.env` file by running the following command:
 
@@ -226,7 +226,7 @@ In the above example, that would be:
 0x6cA1217BdA63ff36c37F48516803015138D66cE6
 ```
 
-If you are using a token other than Celo or one of its stable coins, you’ll need to send a sufficient amount to that address to accommodate for this airdrop. Otherwise, head back over to the [Alfajores faucet](https://celo.org/developers/faucet) and fund the contract address.
+If you are using a token other than Celo or one of its stable coins, you’ll need to send a sufficient amount to that address to accommodate for this airdrop. Otherwise, head back over to the [Alfajores faucet](https://faucet.celo.org) and fund the contract address.
 
 :::tip
 

--- a/blog/06-14-22-nft-celo/how-to-quickly-build-an-nft-collection-on-celo.md
+++ b/blog/06-14-22-nft-celo/how-to-quickly-build-an-nft-collection-on-celo.md
@@ -50,7 +50,7 @@ MetaMask allows you to connect to the Celo blockchain from your browser. To get 
 ![image](images/1.png)
 
 - Add Alfajores Testnet to MetaMask using the manual setup option here
-- Add CELO to your test account using the [Alfajores Testnet Faucet](https://celo.org/developers/faucet)
+- Add CELO to your test account using the [Alfajores Testnet Faucet](https://faucet.celo.org)
 
 :::tip
 

--- a/blog/10-12-2022-How to build a Bookshop-Marketplace-Dapp/How to build a Bookshop Marketplace Dapp.md
+++ b/blog/10-12-2022-How to build a Bookshop-Marketplace-Dapp/How to build a Bookshop Marketplace Dapp.md
@@ -475,14 +475,14 @@ But first you will create a Celo wallet and deploy your contract to the Celo tes
 - Create a wallet
 ![celo_install_celo_extension_wallet](https://user-images.githubusercontent.com/81568615/206867627-595d5f4b-009a-45a3-a624-de0090e5bbe6.gif)
 
-- Get Celo token for the alfajores testnet from <https://celo.org/developers/faucet>
+- Get Celo token for the alfajores testnet from <https://faucet.celo.org>
 
 ![celo_get_token_from_faucet](https://user-images.githubusercontent.com/81568615/206867828-910e3f67-85e3-468d-9fc0-e024083c130a.gif)
 
 ![celo_create_wallet](https://user-images.githubusercontent.com/81568615/206867880-99866ed5-832c-4931-b5db-1429d751ec99.gif)
 
 - Install the Celo plugin on remix then compile and deploy your contract
-  
+
 ![celo_install_remix_plugin_and_deploy_contract (1)](https://user-images.githubusercontent.com/81568615/206871674-33ec8922-c000-42a6-8707-3cd976ebc940.gif)
 
 Congratulations on reaching this stage so far, You have successfully created your smart contract and deployed it on the Celo blockchain.

--- a/blog/12-05-22-how-to-create-and-test-contract-calls-on-hardhat/how-to-create-and-test-contract-calls-on-hardhat.md
+++ b/blog/12-05-22-how-to-create-and-test-contract-calls-on-hardhat/how-to-create-and-test-contract-calls-on-hardhat.md
@@ -60,7 +60,7 @@ To make transactions on the Alfajores Testnet you need CELO Testnet **tokens**.
 Following this tutorial, you will need **CELO faucets** to deploy and transact on the Celo Alfajores blockchain.
 Getting faucets is always as easy as taking these few baby steps:
 
-1. Head over to the [faucet](https://celo.org/developers/faucet) site for the testnet you need. For example, a Celo Alfajore faucet will give you tokens to interact with the Celo Alfajore testnet (which you will also use in this tutoria).
+1. Head over to the [faucet](https://faucet.celo.org) site for the testnet you need. For example, a Celo Alfajore faucet will give you tokens to interact with the Celo Alfajore testnet (which you will also use in this tutoria).
 
 2. Copy your wallet address from metamask or your preferred wallet and paste it into the tab.
 

--- a/blog/12-25-22-step-by-step-guide-to-deploying-your-first-full-stack-dapp-on-celo/step-by-step-guide-to-deploying-your-first-full-stack-dapp-on-celo.md
+++ b/blog/12-25-22-step-by-step-guide-to-deploying-your-first-full-stack-dapp-on-celo/step-by-step-guide-to-deploying-your-first-full-stack-dapp-on-celo.md
@@ -266,7 +266,7 @@ module.exports = function(deployer) {
 
 ## Steps to deploy Smart Contract
 
-1. We need Faucet For deploying smart contracts on Celo Blockchain. Use [Celo Testnet Faucet](https://celo.org/developers/faucet) to get faucet money input your address which we got from celocli.
+1. We need Faucet For deploying smart contracts on Celo Blockchain. Use [Celo Testnet Faucet](https://faucet.celo.org) to get faucet money input your address which we got from celocli.
 
 2. Now we Gonna Compile the Smart Contract and Check if there are any problems with it.
 

--- a/blog/12-27-2022-Improve-your-Celo-Dapp-Development-With-Tatum/Como-construir-em-Celo-usando-Tatum.md
+++ b/blog/12-27-2022-Improve-your-Celo-Dapp-Development-With-Tatum/Como-construir-em-Celo-usando-Tatum.md
@@ -24,7 +24,7 @@ Neste video mostraremos como você pode realizar um deploy do smart contract ERC
 Para este tutorial não é necessário conhecimento prévio. As ferramentas utilizadas serão:
 
 - Tatum: [Tatum](https://tatum.io/) é a maneira mais rápida de criar, testar e executar aplicativos blockchain. Eles oferecem APIs e SDKs para você implementar sua ideia usando blockchain
-- Faucet: [Faucet](https://celo.org/developers/faucet) é utilizada para adicionar fundos a sua conta de teste na rede Alfajores
+- Faucet: [Faucet](https://faucet.celo.org) é utilizada para adicionar fundos a sua conta de teste na rede Alfajores
 - Alfajores: É a rede de teste da Celo que utilizaremos para demonstração a implantação de um contrato inteligente e também realizar transações dos ativos
 
 ## Requisitos

--- a/blog/12-28-2022-How-to-deploy-an-ERC721-Smart-Contract-using-the-Tatum-API/Como-implantar-um-contrato-inteligente-ERC721-usando-a-API-Tatum.md
+++ b/blog/12-28-2022-How-to-deploy-an-ERC721-Smart-Contract-using-the-Tatum-API/Como-implantar-um-contrato-inteligente-ERC721-usando-a-API-Tatum.md
@@ -27,7 +27,7 @@ Neste video mostraremos como você pode realizar um deploy do smart contract ERC
 Para este tutorial não é necessário conhecimento prévio. As ferramentas utilizadas serão:
 
 - Tatum: [Tatum](https://tatum.io/) é a maneira mais rápida de criar, testar e executar aplicativos blockchain. Eles oferecem APIs e SDKs para você implementar sua ideia usando blockchain
-- Faucet: [Faucet](https://celo.org/developers/faucet) é utilizada para adicionar fundos a sua conta de teste na rede Alfajores
+- Faucet: [Faucet](https://faucet.celo.org) é utilizada para adicionar fundos a sua conta de teste na rede Alfajores
 - Alfajores: É a rede de teste da Celo que utilizaremos para demonstração a implantação de um contrato inteligente e também realizar transações dos ativos
 
 ## Requisitos

--- a/blog/2021-11-16-connect-to-metamask.md
+++ b/blog/2021-11-16-connect-to-metamask.md
@@ -132,7 +132,7 @@ function MetamaskAddToken() {
 
 Let's try to send some CELO on Alfajores. Make sure you are connected to the Alfajores testnet, you can double check by clicking the `Connect to Alfajores Testnet` button above again.
 
-Make sure you have some Alfajores CELO to send. If you need some, you can get some from [the faucet here](https://celo.org/developers/faucet).
+Make sure you have some Alfajores CELO to send. If you need some, you can get some from [the faucet here](https://faucet.celo.org).
 
 ```jsx live
 function MetamaskSendCelo() {

--- a/blog/2022-01-01-hellocelo.md
+++ b/blog/2022-01-01-hellocelo.md
@@ -194,7 +194,7 @@ Run this script again with `node helloCelo.js`. This will print `0`, as we have 
 
 ## Using the faucet
 
-We can get free test CELO and cUSDs on the test network for development via [the Celo Alfajores faucet](https://celo.org/build/faucet).
+We can get free test CELO and cUSDs on the test network for development via [the Celo Alfajores faucet](https://faucet.celo.org).
 
 Copy your randomly generated account address from the console output mentioned above, and paste it into the faucet.
 

--- a/blog/2022-01-02-hellocontracts.md
+++ b/blog/2022-01-02-hellocontracts.md
@@ -190,7 +190,7 @@ After a few seconds of syncing (with [Celo's ultralight sync](/protocol/consensu
 docker exec celo-ultralight-node geth attach --exec 'eth.getBalance("<YOUR-ACCOUNT-ADDRESS>")'
 ```
 
-If you go to our [Alfajores Faucet Page](https://celo.org/build/faucet), you should be able to faucet your account some CELO and see your balance increase with the above command.
+If you go to our [Alfajores Faucet Page](https://faucet.celo.org), you should be able to faucet your account some CELO and see your balance increase with the above command.
 
 ### Deploy the contract
 

--- a/blog/2022-01-02-hellocontracts.md
+++ b/blog/2022-01-02-hellocontracts.md
@@ -218,4 +218,4 @@ truffle migrate --network alfajores
 
 You can verify your contract deployment on [Blockscout](https://alfajores-blockscout.celo-testnet.org/), as well as interact with your new contract with the `truffle console --network alfajores`. Congratulations!
 
-As you can see, all the goodies from Ethereum apply to Celo, so virtually all tutorials and other content should be easily translatable to Celo. Check out [https://celo.org/build](https://celo.org/build) for more resources!
+As you can see, all the goodies from Ethereum apply to Celo, so virtually all tutorials and other content should be easily translatable to Celo. Check out [https://celo.org/developers](https://celo.org/developers) for more resources!

--- a/blog/2022-01-03-hello-contract-remote-node.md
+++ b/blog/2022-01-03-hello-contract-remote-node.md
@@ -127,7 +127,7 @@ Here are the steps to go through to deploy the contract to the Alfajores testnet
 
 1. Connect to Forno \(a remote Celo node service provider\)
 2. Get personal account information \(generate a private key if required, stored in `./.env`\)
-3. Get your personal account address and fund it via the [faucet](https://celo.org/build/faucet)
+3. Get your personal account address and fund it via the [faucet](https://faucet.celo.org)
 4. Get the compiled contract bytecode
 5. Create and sign the contract deployment transaction
 6. Send transaction to the network
@@ -153,7 +153,7 @@ console.log(web3.eth.accounts.create());
 
 The provided code will print a private key / account pair in the terminal. Copy and paste the printed `priavteKey` into a `PRIVATE_KEY` variable in a file called `.env`, similar to what is shown in the `.envexample` file. The `address` that is printed with the private key is the account that we will fund with the faucet.
 
-If you go to the [Alfajores Faucet Page](https://celo.org/build/faucet), you can faucet your account some CELO and see your balance increase.
+If you go to the [Alfajores Faucet Page](https://faucet.celo.org), you can faucet your account some CELO and see your balance increase.
 
 ### Deploy the contract
 
@@ -248,7 +248,7 @@ async function awaitWrapper() {
   kit.connection.addAccount(process.env.PRIVATE_KEY); // this account must have a CELO balance to pay transaction fees
 
   // This account must have a CELO balance to pay tx fees
-  // get some testnet funds at https://celo.org/build/faucet
+  // get some testnet funds at https://faucet.celo.org
   const address = privateKeyToAddress(process.env.PRIVATE_KEY);
   console.log(address);
 
@@ -309,7 +309,7 @@ The `setName()` function is a bit more involved. First, it gets the account key 
 ```javascript title="helloWorld.js"
 async function setName(instance, newName) {
   // Add your account to ContractKit to sign transactions
-  // This account must have a CELO balance to pay tx fees, get some https://celo.org/build/faucet
+  // This account must have a CELO balance to pay tx fees, get some https://faucet.celo.org
   kit.connection.addAccount(process.env.PRIVATE_KEY);
   const address = privateKeyToAddress(process.env.PRIVATE_KEY);
 

--- a/blog/2022-01-03-hello-contract-remote-node.md
+++ b/blog/2022-01-03-hello-contract-remote-node.md
@@ -328,4 +328,4 @@ The above method shows a more detail about how to create custom deployment trans
 
 As you can see, all the goodies from Ethereum apply to Celo, so virtually all tutorials and other content should be easily translatable to Celo.
 
-Check out [https://celo.org/build](https://celo.org/build) for more resources!
+Check out [https://celo.org/developers](https://celo.org/developers) for more resources!

--- a/blog/2022-01-04-no-code-erc20.md
+++ b/blog/2022-01-04-no-code-erc20.md
@@ -25,7 +25,7 @@ In this tutorial, we will go over how to deploy an ERC20 token contract. The pro
 
 1. Install [Metamask](https://metamask.io/).
 2. [Add the Celo network](/wallet/metamask/setup#adding-a-celo-network-to-metamask) to Metamask. We suggest adding the Alfajores testnet to Metamask as well, so you can test contract deployments before deploying to mainnet.
-3. Add a small amount of CELO to your Metamask account. In this example, we will deploy to the Alfajores testnet, so we need Alfajores CELO, which you can get from the faucet [here](https://celo.org/developers/faucet).
+3. Add a small amount of CELO to your Metamask account. In this example, we will deploy to the Alfajores testnet, so we need Alfajores CELO, which you can get from the faucet [here](https://faucet.celo.org).
 4. Go to the [Open Zeppelin Contracts Wizard](https://docs.openzeppelin.com/contracts/4.x/wizard).
 5. Select `ERC20` as the type of contract that you would like to deploy.
 

--- a/blog/2022-01-05-no-code-erc721.md
+++ b/blog/2022-01-05-no-code-erc721.md
@@ -27,7 +27,7 @@ In this example, we will be using IPFS for off-chain storage, but you can use wh
 
 1. Install [Metamask](https://metamask.io/).
 2. [Add the Celo network](/wallet/metamask/setup#adding-a-celo-network-to-metamask) to Metamask. We suggest adding the Alfajores testnet to Metamask as well, so you can test contract deployments before deploying to mainnet.
-3. Add a small amount of CELO to your Metamask account. In this example, we will deploy to the Alfajores testnet, so we need Alfajores CELO, which you can get from the faucet [here](https://celo.org/developers/faucet).
+3. Add a small amount of CELO to your Metamask account. In this example, we will deploy to the Alfajores testnet, so we need Alfajores CELO, which you can get from the faucet [here](https://faucet.celo.org).
 
 ## Prepare the NFT metadata
 

--- a/blog/2022-02-21-introduction-to-celo-progressive-dappstarter.md
+++ b/blog/2022-02-21-introduction-to-celo-progressive-dappstarter.md
@@ -101,7 +101,7 @@ npx hardhat create-account
 
 ![dappstarter](/img/doc-images/introduction-to-celo-progressive-dappstarter/7.png)
 
-Copy the testnet account address, paste it into the [Celo Testnet Faucet](https://celo.org/developers/faucet) and select **Get Started** to transfer funds into your testnet account.
+Copy the testnet account address, paste it into the [Celo Testnet Faucet](https://faucet.celo.org) and select **Get Started** to transfer funds into your testnet account.
 
 ![dappstarter](/img/doc-images/introduction-to-celo-progressive-dappstarter/8.png)
 

--- a/blog/2022-06-20-React-Native-&-Celo-Easily-build-React-Native-dApps-on-Celo.md
+++ b/blog/2022-06-20-React-Native-&-Celo-Easily-build-React-Native-dApps-on-Celo.md
@@ -170,7 +170,7 @@ Copy your address.
 
 ![valora-wallet-address](https://user-images.githubusercontent.com/38040789/195802458-f76995ec-99c2-4312-84a6-ddf5c60516b3.png)
 
-In the browser go to — https://celo.org/developers/faucet
+In the browser go to — https://faucet.celo.org
 
 ![funding-testnet-wallet](https://user-images.githubusercontent.com/38040789/195802514-fced0fbc-87b5-4028-bc1e-1a852e718896.png)
 

--- a/blog/2022-06-27-flutter-celo-easily-build-flutter-mobile-dApps.md
+++ b/blog/2022-06-27-flutter-celo-easily-build-flutter-mobile-dApps.md
@@ -70,7 +70,7 @@ flutter run
 
 #### Get some testnet Celo tokens on Valora
 
-Get your address from the Valora app and go to the [Celo faucet](https://celo.org/developers/faucet) site.
+Get your address from the Valora app and go to the [Celo faucet](https://faucet.celo.org) site.
 
 ![Celo Faucet](./images/1_e-0iwxIiYVRnXc5-_ZhLIg.png)
 

--- a/blog/29-12-22-crowdfunding-using-hardhat/Create a Crowdfunding Smart Contract on Celo using Hardhat.md
+++ b/blog/29-12-22-crowdfunding-using-hardhat/Create a Crowdfunding Smart Contract on Celo using Hardhat.md
@@ -34,7 +34,7 @@ These are the prerequisites you will need for this tutorial:
 
 - Have a [Metamask extension](https://metamask.io/)
 - [Configure](https://docs.celo.org/blog/tutorials/3-simple-steps-to-connect-your-metamask-wallet-to-celo) your Metamask to Celo
-- [Fund your Celo account](https://celo.org/developers/faucet) on Metamask
+- [Fund your Celo account](https://faucet.celo.org) on Metamask
 
 ### A Brief Overview of Celo
 

--- a/blog/celo-spotlight/celo-spotlight.md
+++ b/blog/celo-spotlight/celo-spotlight.md
@@ -265,7 +265,7 @@ Make use of [Celo Dollars (cUSD)](https://coinmarketcap.com/currencies/celo-doll
 
 ### Get Test Funds
 
-Get testnet funds by switching your [Celo Wallet](https://celo.org/developers/wallet) or [MetaMask Wallet](https://docs.celo.org/developer-resources/testnet-wallet) to the [Alfajores testnet](/network). Send your wallet funds for testing or development using the [Alfajores testnet faucet](https://celo.org/developers/faucet).
+Get testnet funds by switching your [Celo Wallet](https://celo.org/developers/wallet) or [MetaMask Wallet](https://docs.celo.org/developer-resources/testnet-wallet) to the [Alfajores testnet](/network). Send your wallet funds for testing or development using the [Alfajores testnet faucet](https://faucet.celo.org).
 
 :::tip
 

--- a/blog/hardhat-celo/hardhat-and-celo-the-ultimate-guide-to-deploy-celo-dapps-using-hardhat.md
+++ b/blog/hardhat-celo/hardhat-and-celo-the-ultimate-guide-to-deploy-celo-dapps-using-hardhat.md
@@ -259,7 +259,7 @@ Learn more: [Celo CLI: A practical guide to energize your Celo toolkit](https://
 
 ### Fund your account
 
-The [Alfajores testnet faucet](https://celo.org/developers/faucet) helps you fund your account with test tokens. Copy your address from the terminal and paste it into the site to fund your account. This should send you tokens within a few seconds.
+The [Alfajores testnet faucet](https://faucet.celo.org) helps you fund your account with test tokens. Copy your address from the terminal and paste it into the site to fund your account. This should send you tokens within a few seconds.
 
 ![image](images/17.png)
 

--- a/blog/truffle-and-celo/truffle-and-celo.md
+++ b/blog/truffle-and-celo/truffle-and-celo.md
@@ -239,7 +239,7 @@ Learn more: [Celo CLI: A practical guide to energize your Celo toolkit](https://
 
 ### Fund your account
 
-The [Alfajores testnet faucet](https://celo.org/developers/faucet) helps you fund your account with test tokens. Copy your address from the terminal and paste it into the site to fund your account. This should send you tokens within a few seconds.
+The [Alfajores testnet faucet](https://faucet.celo.org) helps you fund your account with test tokens. Copy your address from the terminal and paste it into the site to fund your account. This should send you tokens within a few seconds.
 
 ![image](images/16.png)
 

--- a/docs/community/join-the-community.md
+++ b/docs/community/join-the-community.md
@@ -32,7 +32,7 @@ Ask questions, find answers, and get in touch.
 - [Celo Forum](https://forum.celo.org/)
 - [Celo Developer Chat on Discord](https://chat.celo.org/)
 - [Celo Subreddit](https://www.reddit.com/r/celo/)
-- [Celo Website](https://celo.org/build)
+- [Celo Website](https://celo.org/developers)
 - [Host a Meetup](https://airtable.com/shrTCM7LddTxOm3r6)
 
 ## Contributions
@@ -42,4 +42,4 @@ Browse the code, raise an issue, or contribute a pull request.
 - [Monorepo GitHub Page](https://github.com/celo-org/celo-monorepo)
 - [Celo Client GitHub Page](https://github.com/celo-org/celo-blockchain)
 - [Contributing Guide](https://docs.celo.org/community/contributing)
-- [Celo Build Page](https://celo.org/build)
+- [Celo Developers Page](https://celo.org/developers)

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -53,4 +53,4 @@ Easily build Celo dApps with Celo Composer.
 
 - [EVM Compatible Tooling](/developer/evm-tools)
 - [Block Explorer](https://explorer.celo.org/)
-- [Testnet Faucet](https://celo.org/developers/faucet)
+- [Testnet Faucet](https://faucet.celo.org)

--- a/docs/developer/setup/wallet.md
+++ b/docs/developer/setup/wallet.md
@@ -124,7 +124,7 @@ If you created an account using option 2 or 3, you can now import these accounts
 
 No matter where you created your accounts, you can send them testnet funds using your **Account Address** and the testnet faucet.
 
-- Navigate to the [Alfajores Testnet Faucet](https://celo.org/developers/faucet)
+- Navigate to the [Alfajores Testnet Faucet](https://faucet.celo.org)
 - Copy your address from your terminal or wallet
 - Paste this address into the **Testnet Faucet**, complete the **Captcha**, and click **Get Started**
 

--- a/docs/developer/walkthrough/hello-celo.md
+++ b/docs/developer/walkthrough/hello-celo.md
@@ -182,7 +182,7 @@ Run this script again with `node helloCelo.js`. This will print `0`, as we have 
 
 ## Using the faucet
 
-We can get free test CELO and Mento cUSDs on the test network for development via [the Celo Alfajores faucet](https://celo.org/build/faucet).
+We can get free test CELO and Mento cUSDs on the test network for development via [the Celo Alfajores faucet](https://faucet.celo.org).
 
 Copy your randomly generated account address from the console output mentioned above, and paste it into the faucet.
 

--- a/docs/developer/walkthrough/hello-contract-remote-node.md
+++ b/docs/developer/walkthrough/hello-contract-remote-node.md
@@ -317,4 +317,4 @@ The above method shows a more detail about how to create custom deployment trans
 
 As you can see, all the goodies from Ethereum apply to Celo, so virtually all tutorials and other content should be easily translatable to Celo.
 
-Check out [https://celo.org/build](https://celo.org/build) for more resources!
+Check out [https://celo.org/developers](https://celo.org/developers) for more resources!

--- a/docs/developer/walkthrough/hello-contract-remote-node.md
+++ b/docs/developer/walkthrough/hello-contract-remote-node.md
@@ -116,7 +116,7 @@ Here are the steps to go through to deploy the contract to the Alfajores testnet
 
 1. Connect to Forno \(a remote Celo node service provider\)
 2. Get personal account information \(generate a private key if required, stored in `./.env`\)
-3. Get your personal account address and fund it via the [faucet](https://celo.org/build/faucet)
+3. Get your personal account address and fund it via the [faucet](https://faucet.celo.org)
 4. Get the compiled contract bytecode
 5. Create and sign the contract deployment transaction
 6. Send transaction to the network
@@ -142,7 +142,7 @@ console.log(web3.eth.accounts.create());
 
 The provided code will print a private key / account pair in the terminal. Copy and paste the printed `priavteKey` into a `PRIVATE_KEY` variable in a file called `.env`, similar to what is shown in the `.envexample` file. The `address` that is printed with the private key is the account that we will fund with the faucet.
 
-If you go to the [Alfajores Faucet Page](https://celo.org/build/faucet), you can faucet your account some CELO and see your balance increase.
+If you go to the [Alfajores Faucet Page](https://faucet.celo.org), you can faucet your account some CELO and see your balance increase.
 
 ### Deploy the contract
 
@@ -237,7 +237,7 @@ async function awaitWrapper() {
   kit.connection.addAccount(process.env.PRIVATE_KEY); // this account must have a CELO balance to pay transaction fees
 
   // This account must have a CELO balance to pay tx fees
-  // get some testnet funds at https://celo.org/build/faucet
+  // get some testnet funds at https://faucet.celo.org
   const address = privateKeyToAddress(process.env.PRIVATE_KEY);
   console.log(address);
 
@@ -298,7 +298,7 @@ The `setName()` function is a bit more involved. First, it gets the account key 
 ```javascript title="helloWorld.js"
 async function setName(instance, newName) {
   // Add your account to ContractKit to sign transactions
-  // This account must have a CELO balance to pay tx fees, get some https://celo.org/build/faucet
+  // This account must have a CELO balance to pay tx fees, get some https://faucet.celo.org
   kit.connection.addAccount(process.env.PRIVATE_KEY);
   const address = privateKeyToAddress(process.env.PRIVATE_KEY);
 

--- a/docs/developer/walkthrough/hello-contracts.md
+++ b/docs/developer/walkthrough/hello-contracts.md
@@ -179,7 +179,7 @@ After a few seconds of syncing (with [Celo's ultralight sync](/protocol/consensu
 docker exec celo-ultralight-node geth attach --exec 'eth.getBalance("<YOUR-ACCOUNT-ADDRESS>")'
 ```
 
-If you go to our [Alfajores Faucet Page](https://celo.org/build/faucet), you should be able to faucet your account some CELO and see your balance increase with the above command.
+If you go to our [Alfajores Faucet Page](https://faucet.celo.org), you should be able to faucet your account some CELO and see your balance increase with the above command.
 
 ### Deploy the contract
 
@@ -207,4 +207,4 @@ truffle migrate --network alfajores
 
 You can verify your contract deployment on [Blockscout](https://alfajores-blockscout.celo-testnet.org/), as well as interact with your new contract with the `truffle console --network alfajores`. Congratulations!
 
-As you can see, all the goodies from Ethereum apply to Celo, so virtually all tutorials and other content should be easily translatable to Celo. Check out [https://celo.org/build](https://celo.org/build) for more resources!
+As you can see, all the goodies from Ethereum apply to Celo, so virtually all tutorials and other content should be easily translatable to Celo. Check out [https://celo.org/developers](https://celo.org/developers) for more resources!

--- a/docs/developer/walkthrough/no-code-erc20.md
+++ b/docs/developer/walkthrough/no-code-erc20.md
@@ -15,7 +15,7 @@ In this tutorial, we will go over how to deploy an ERC20 token contract. The pro
 
 1. Install [Metamask](https://metamask.io/).
 2. [Add the Celo network](/wallet/metamask/setup#adding-a-celo-network-to-metamask) to Metamask. We suggest adding the Alfajores testnet to Metamask as well, so you can test contract deployments before deploying to mainnet.
-3. Add a small amount of CELO to your Metamask account. In this example, we will deploy to the Alfajores testnet, so we need Alfajores CELO, which you can get from the faucet [here](https://celo.org/developers/faucet).
+3. Add a small amount of CELO to your Metamask account. In this example, we will deploy to the Alfajores testnet, so we need Alfajores CELO, which you can get from the faucet [here](https://faucet.celo.org).
 4. Go to the [Open Zeppelin Contracts Wizard](https://docs.openzeppelin.com/contracts/4.x/wizard).
 5. Select `ERC20` as the type of contract that you would like to deploy.
 

--- a/docs/developer/walkthrough/no-code-erc721.md
+++ b/docs/developer/walkthrough/no-code-erc721.md
@@ -17,7 +17,7 @@ In this example, we will be using IPFS for off-chain storage, but you can use wh
 
 1. Install [Metamask](https://metamask.io/).
 2. [Add the Celo network]((/wallet/metamask/setup#adding-a-celo-network-to-metamask) to Metamask. We suggest adding the Alfajores testnet to Metamask as well, so you can test contract deployments before deploying to mainnet.
-3. Add a small amount of CELO to your Metamask account. In this example, we will deploy to the Alfajores testnet, so we need Alfajores CELO, which you can get from the faucet [here](https://celo.org/developers/faucet).
+3. Add a small amount of CELO to your Metamask account. In this example, we will deploy to the Alfajores testnet, so we need Alfajores CELO, which you can get from the faucet [here](https://faucet.celo.org).
 
 ## Prepare the NFT metadata
 

--- a/docs/learn/Celo-payments.md
+++ b/docs/learn/Celo-payments.md
@@ -67,7 +67,7 @@ source .env
 echo $accountAddress | pbcopy
 
 # Head to the faucet to get some money and paste your account address there
-open https://celo.org/developers/faucet
+open https://faucet.celo.org
 
 # Verify you got money successfully
 celocli account:balance $accountAddress

--- a/docs/learn/celo-onboarding.md
+++ b/docs/learn/celo-onboarding.md
@@ -45,7 +45,7 @@ With its interoperability, cross-chain compatibility and vision for inclusivity,
 - [Valora](https://valoraapp.com/)
 - [Get CELO](https://celohub.org/purchase)
 - [Get a Test Wallet](https://celo.org/developers/wallet)
-- [Get Test Funds](https://celo.org/developers/faucet)
+- [Get Test Funds](https://faucet.celo.org)
 - [Block Explorer](https://explorer.celo.org/)
 
 ## Connect with the Community

--- a/docs/network/alfajores/faucet.md
+++ b/docs/network/alfajores/faucet.md
@@ -65,7 +65,7 @@ export CELO_ACCOUNT_ADDRESS=<YOUR-ACCOUNT-ADDRESS>
 
 The Alfajores Testnet Faucet is an easy way to get more funds deposited to an account, however it was created.
 
-Visit [celo.org/build/faucet](https://celo.org/build/faucet), and enter your account address. If you are using the Celo Wallet, you can find your account address in the Settings page. Complete the Captcha, and click 'Add Funds'.
+Visit [faucet.celo.org](https://faucet.celo.org), and enter your account address. If you are using the Celo Wallet, you can find your account address in the Settings page. Complete the Captcha, and click 'Add Funds'.
 
 Each time you complete a faucet request, your account is funded with an additional 10 Celo Dollars and 5 CELO.
 

--- a/docs/network/alfajores/use-mobile-wallet.md
+++ b/docs/network/alfajores/use-mobile-wallet.md
@@ -15,7 +15,7 @@ Since verifying your phone number costs gas, you have to be invited to the platf
 
 If you already have an account \(and the corresponding seed phrase\), you can download the Celo wallet from the [play store](https://play.google.com/store/apps/details?id=org.celo.mobile.alfajores) and follow instructions in the app to import your wallet using the seed phrase.
 
-If you need more funds, you can always visit [celo.org/build/faucet](https://celo.org/build/faucet) and enter your address to get more Celo Dollars.
+If you need more funds, you can always visit [faucet.celo.org](https://faucet.celo.org) and enter your address to get more Celo Dollars.
 
 ![Verifying your phone number with an invitation code](https://storage.googleapis.com/celo-website/docs/celo-onboarding.gif)
 

--- a/docs/network/index.md
+++ b/docs/network/index.md
@@ -25,7 +25,7 @@ If you're a developer considering building on the Celo platform, or want to try 
 
 - [Alfajores Testnet Block Explorer](https://alfajores-blockscout.celo-testnet.org)
 - [Alfajores Network Status](https://alfajores-celostats.celo-testnet.org)
-- [Alfajores Testnet Faucet](https://celo.org/build/faucet)
+- [Alfajores Testnet Faucet](https://faucet.celo.org)
 - [Celo Wallet for Alfajores](https://celo.org/build/wallet)
 
 **Chain ID:** `44787`

--- a/docs/wallet/ledger/to-celo-cli.md
+++ b/docs/wallet/ledger/to-celo-cli.md
@@ -99,7 +99,7 @@ Before using your address on the Celo Mainnet, you may want to test it on the Ce
 
 Visit the Alfajores Faucet and send yourself some testnet CELO at the following URL:
 
-https://celo.org/developers/faucet
+https://faucet.celo.org
 
 Check that you received the funds with the following command:
 

--- a/docs/wallet/mobile-wallet/setup.md
+++ b/docs/wallet/mobile-wallet/setup.md
@@ -15,7 +15,7 @@ Since verifying your phone number costs gas, you have to be invited to the platf
 
 If you already have an account \(and the corresponding seed phrase\), you can download the Celo wallet from the [play store](https://play.google.com/store/apps/details?id=org.celo.mobile.alfajores) and follow instructions in the app to import your wallet using the seed phrase.
 
-If you need more funds, you can always visit [celo.org/build/faucet](https://celo.org/build/faucet) and enter your address to get more Celo Dollars.
+If you need more funds, you can always visit [faucet.celo.org](https://faucet.celo.org) and enter your address to get more Celo Dollars.
 
 ![Verifying your phone number with an invitation code](https://storage.googleapis.com/celo-website/docs/celo-onboarding.gif)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -461,7 +461,7 @@ const sidebars = {
         {
           type: "link",
           label: "Faucet",
-          href: "https://celo.org/developers/faucet",
+          href: "https://faucet.celo.org",
         },
       ],
     },


### PR DESCRIPTION

Updates all Faucet Links to go to Faucet.celo.org


also updates celo.org/build  links to celo.org/developers 

build was essentially the developers page a long time ago and no longer exists