### PR TITLE
fix careers link

### DIFF
--- a/docs/learn/celo-onboarding.md
+++ b/docs/learn/celo-onboarding.md
@@ -32,7 +32,7 @@ With its interoperability, cross-chain compatibility and vision for inclusivity,
 ## Celo Tour
 
 - [About Celo](https://celo.org/about)
-- [Join](https://celo.org/jobs)
+- [Join](https://celo.org/careers)
 - [Validators](https://celo.org/validators)
 - [Developers](https://celo.org/developers)
 - [Alliance](https://celo.org/alliance)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -272,7 +272,7 @@ module.exports = {
             },
             {
               label: "Careers",
-              href: "https://celo.org/jobs",
+              href: "https://celo.org/careers",
             },
           ],
         },

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -57,7 +57,7 @@
   },
   "link.item.label.Careers": {
     "message": "Careers",
-    "description": "The label of footer link with label=Careers linking to https://celo.org/jobs"
+    "description": "The label of footer link with label=Careers linking to https://celo.org/careers"
   },
   "copyright": {
     "message": "Copyright © 2022 Celo Foundation, Inc. Built with Docusaurus.",


### PR DESCRIPTION
## fix careers link

Browsing the website I realize the Careers link were pointing to a route on celo.org that does not exist anymore.