### PR TITLE
Updating the URL for closer

### DIFF
--- a/src/data/users.tsx
+++ b/src/data/users.tsx
@@ -1095,7 +1095,7 @@ const Users: User[] = [
     title: 'Closer',
     description: 'Suite of web3 tools to bootstrap regenerative action and meaningful governance in local communities',
     preview: require('./showcase/closer.png'),
-    website: 'https://www.wildchain.io/',
+    website: 'https://closer.earth/',
     source: 'https://github.com/closerearth',
     tags: ['refi'],
   },


### PR DESCRIPTION
The URL for closer.earth was pointing to wildchain. Updating to point to the correct website.