### PR TITLE
Update mainnet node requirements from 256GB to 4TB

### DIFF
--- a/docs/validator/run/mainnet.md
+++ b/docs/validator/run/mainnet.md
@@ -50,7 +50,7 @@ Celo is a proof-of-stake network, which has different hardware requirements than
 
 - Memory: 8 GB RAM
 - CPU: Quad core 3GHz (64-bit)
-- Disk: 256 GB of SSD storage, plus a secondary HDD desirable
+- Disk: 4 TB of SSD storage, plus a secondary HDD desirable
 - Network: At least 1 GB input/output Ethernet with a fiber Internet connection, ideally redundant connections and HA switches
 
 In addition, to get things started, it will be useful to run a node on your local machine that you can issue CLI commands against.


### PR DESCRIPTION
Currently, the mainnet is nearly two terabytes of data in size. Modifying the recommended size to 4TB for nodes to sustain storage over time.