### PR TITLE
Remove old python and java SDKs

### DIFF
--- a/docs/developer/sdks/celo-sdks.md
+++ b/docs/developer/sdks/celo-sdks.md
@@ -19,5 +19,3 @@ List of Celo libraries & SDKs
 - [ContractKit](../contractkit/index.md)
 - [Rainbowkit-Celo](../rainbowkit-celo/index.md)
 - [iOS SDK](https://github.com/heymateag/celoiossdk)
-- [Java SDK](https://github.com/blaize-tech/celo-sdk-java)
-- [Python SDK](https://github.com/blaize-tech/celo-sdk-py/)

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -65,10 +65,8 @@ Connect to Celo using a variety of APIs and SDKs for iOS, Java, React, and more.
 
 - [CLI](cli)
 - [IOS](https://github.com/heymateag/celoiossdk)
-- [Java](https://github.com/blaize-tech/celo-sdk-java)
 - [React](https://github.com/celo-org/react-celo)
 - [Flutter](https://github.com/viral-sangani/walletconnect_flutter)
-- [Python](https://github.com/blaize-tech/celo-sdk-py/)
 - [Javascript](https://github.com/celo-org/celo-monorepo/tree/master/packages/sdk/contractkit)
 
 ### Join the Community

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -170,14 +170,6 @@ module.exports = {
               label: "iOS SDK",
             },
             {
-              to: "https://github.com/blaize-tech/celo-sdk-java",
-              label: "Java SDK",
-            },
-            {
-              to: "https://github.com/blaize-tech/celo-sdk-py/",
-              label: "Python SDK",
-            },
-            {
               label: "Celo Composer",
               to: "https://github.com/celo-org/celo-composer#celo-composer",
             },


### PR DESCRIPTION
These two have not been updated since 2020, so they lack support for
 all Celo changes since then (e.g. base fees) and have outdated
 dependencies. Users are better off using any actively maintained
 Ethereum tooling rather than these.