### PR TITLE
Update gitcoin bounties link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1092,7 +1092,7 @@ const sidebars = {
         {
           type: "link",
           label: "Bounties",
-          href: "https://gitcoin.co/celo-org/projects",
+          href: "https://bounties.gitcoin.co/celo-org/bounties",
         },
         {
           type: "doc",


### PR DESCRIPTION
The old link 404s and this looks like the right replacement.