### PR TITLE
Remove Ambassadors link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1101,11 +1101,6 @@ const sidebars = {
         },
         {
           type: "link",
-          label: "Ambassadors",
-          href: "https://celocommunity.xyz/join-the-ambassador-program",
-        },
-        {
-          type: "link",
           label: "Code of Conduct",
           href: "https://github.com/celo-org/website/blob/master/src/content/code-of-conduct.md",
         },


### PR DESCRIPTION
The linked domain is not even registered anymore and I can't find a trace of an active ambassadors program.