### PR TITLE
Remove Cannoli testnet from docs

### DIFF
--- a/docs/network/index.md
+++ b/docs/network/index.md
@@ -62,22 +62,6 @@ The Baklava Testnet is designed for testing and experimentation by developers. I
 
 Your use of the Baklava Testnet is subject to the [Baklava Testnet Disclaimer](/network/baklava/disclaimer).
 
-:::
-
-## Cannoli, the Ultragreen Testnet
-
-For Earth Day 2023, the Celo Community has proposed a new [Ultragreen CIP](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0052.md), which strives to position Celo to become deflationary as well as further Celo's sustainability commitment . With each transaction, [CIP-52](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0052.md) proposes that 80% of the base fee would be burned and 20% would be sent to a Carbon Offset address to purchase high-quality carbon offsets. This testnet is intended to support this new ‘Ultragreen’ mechanism before this change is later proposed for a future hardfork.
-
-**Links:**
-
-- [Cannoli Testnet Block Explorer](https://explorer.celo.org/cannoli)
-- [Cannoli Testnet Faucet](https://faucet.celo.org/cannoli)
-- [Cannoli Forno RPC provider](https://docs.celo.org/network/node/forno#what-is-forno): `https://forno.cannoli.celo-testnet.org`
-
-**Chain ID:** `17323`
-
-:::info
-
 Your use of the Cannoli Testnet is subject to the [Cannoli Testnet Disclaimer](/network/cannoli/disclaimer).
 
 :::

--- a/docs/network/index.md
+++ b/docs/network/index.md
@@ -5,7 +5,7 @@ description: How to choose a Celo network based on your interested and objective
 
 # Networks
 
-Overview of Celo Mainnet, Alfajores Testnet, Baklava Testnet, and Cannoli Testnet.
+Overview of Celo Mainnet, Alfajores Testnet and Baklava Testnet.
 
 ---
 
@@ -61,7 +61,5 @@ The Baklava Testnet is designed for testing and experimentation by developers. I
 :::info
 
 Your use of the Baklava Testnet is subject to the [Baklava Testnet Disclaimer](/network/baklava/disclaimer).
-
-Your use of the Cannoli Testnet is subject to the [Cannoli Testnet Disclaimer](/network/cannoli/disclaimer).
 
 :::


### PR DESCRIPTION
Cannoli testnet is deprecated an plan is to delete next Wednesday Nov. 1st:

https://forum.celo.org/t/cannoli-testnet-deprecation-announcement/6796