### PR TITLE
s/applications/devtooling/g

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,13 +3,13 @@
 # See [Github Documentation](https://help.github.com/articles/about-codeowners/).
 
 * @celo-org/devrel 
-/docs/cli/ @celo-org/devrel @celo-org/applications
-/docs/developer/contractkit/ @celo-org/devrel @celo-org/applications
-/docs/developer/dappkit/ @celo-org/devrel @celo-org/applications
+/docs/cli/ @celo-org/devrel @celo-org/devtooling
+/docs/developer/contractkit/ @celo-org/devrel @celo-org/devtooling
+/docs/developer/dappkit/ @celo-org/devrel @celo-org/devtooling
 /docs/developer/deploy/ @celo-org/devrel @celo-org/primitives
-/docs/developer/rainbowkit-celo/ @celo-org/devrel @celo-org/applications
-/docs/developer/react-celo/ @celo-org/devrel @celo-org/applications
-/docs/developer/sdks/ @celo-org/devrel @celo-org/applications
-/docs/developer/viem/ @celo-org/devrel @celo-org/applications
+/docs/developer/rainbowkit-celo/ @celo-org/devrel @celo-org/devtooling
+/docs/developer/react-celo/ @celo-org/devrel @celo-org/devtooling
+/docs/developer/sdks/ @celo-org/devrel @celo-org/devtooling
+/docs/developer/viem/ @celo-org/devrel @celo-org/devtooling
 /docs/network/node/ @celo-org/devrel @celo-org/devopsre
 /docs/protocol/identity/ @celo-org/devrel @celo-org/primitives


### PR DESCRIPTION
### Description

s/applications/devtooling/g

### Tested

GitHub CODEOWNERS file validation.

### Backwards compatibility

This is not backwards compatible: previous mentions of @celo-org/applications are broken.