### PR TITLE
Update client release docs

### DIFF
--- a/docs/community/release-process/blockchain-client.md
+++ b/docs/community/release-process/blockchain-client.md
@@ -13,30 +13,11 @@ Details of the release process for updating the blockchain client on the Celo pl
 
 Releases of celo-blockchain are numbered according to semantic versioning, as described at [semver.org](https://semver.org).
 
-New releases of celo-blockchain can be expected as follows:
-
-- Major releases: approximately yearly
-- Minor releases: approximately 4 times a year
-- Patch releases: as needed
-
 All builds are identified as `unstable` (a development build) or `stable` (a commit released as a particular version number). There should only ever exist one commit with a version `x.y.z-stable` for any `(x, y, z)`.
 
 ### Signatures
 
-Artifacts produced by this build process (e.g. tags, binaries, Docker images) will be signed. Signatures are produced using any one of the core developer keys listed below.
-
-Public keys for corek developers are hosted on celo.org and can be imported to `gpg` with the following command:
-
-```bash
-gpg --auto-key-locate wkd --locate-keys $EMAIL
-```
-
-Currently hosted core developer keys include:
-
-- joshua@clabs.co
-- mariano@clabs.co
-- or@clabs.co
-- victor@clabs.co
+Artifacts produced by this build process (e.g. Docker images) will be signed by [cosign](https://github.com/sigstore/cosign).
 
 ## Documentation
 
@@ -52,7 +33,9 @@ Development is done on the `master` branch, which corresponds to the next major 
 
 ### Git tags
 
-All releases should be tagged with the version number, e.g. `vX.Y.Z`. Each release should include a summary of the release contents, including links to pull requests and issues with detailed description of any notable changes.
+All releases should be tagged with the version number, e.g. `vX.Y.Z`. Each release should include a
+summary of the release contents, including links to pull requests and issues with detailed
+description of any notable changes.
 
 Tags should be signed and can be verified with the following command.
 
@@ -60,25 +43,14 @@ Tags should be signed and can be verified with the following command.
 git verify-tag vX.Y.Z
 ```
 
-On Github, each release tag should have attached the Geth binaries for supported platforms, along with signatures that can be used to verify the binary and Docker images.
+On Github, each release tag should link to the respective Docker image, along with signatures that
+can be used to verify those images.
 
 ### Docker tags
 
 Each released Docker image should should be tagged with it’s version number such that for release `x.y.z`, the image should have tags `x`, `x.y`, and `x.y.z`, with the first two tags potentially being moved from a previous image. Just as a Git tag `x.y.z` immutably points to a commit hash, the Docker tag, `x.y.z` should immutably point to an image hash.
 
 ## Build process
-
-### Binaries
-
-Binaries for common platforms are built automatically with [Google Cloud Build](https://cloud.google.com/cloud-build) upon pushes to `master` and all release branches.
-
-A signature should be produced over the binary automatically built at the corresponding commit hash and included in the Github release.
-
-Release binary signatures can be verified with the following command:
-
-```bash
-gpg --verify celo-blockchain-vX.Y.Z-stable.tar.gz.asc celo-blockchain-vX.Y.Z-stable.tar.gz
-```
 
 ### Docker images
 
@@ -108,58 +80,6 @@ Major and minor releases should be constructed by pushing a commit to the `maste
 
 Only one commit should ever have a “stable” tag at any given version number. When that commit is created, a tag should be added along with release notes. Once the tag is published it should not be reused for any further release or changes.
 
-### Distribution
-
-Distribution of an image should occur along the following schedule:
-
-<table>
-  <tr>
-    <td>Date</td>
-    <td>Action</td>
-  </tr>
-  <tr>
-    <td>T</td>
-    <td>
-      <ol>
-        <li>Publish the Git tag and signed release artifacts.</li>
-        <li>Communicate T+1w Baklava upgrade date.</li>
-        <li>Tag released Docker image with <code>baklava</code>.</li>
-      </ol>
-    </td>
-  </tr>
-  <tr>
-    <td>T+1w</td>
-    <td>
-      <ol>
-        <li>Confirm Baklava users have upgraded without issues</li>
-        <li>If release introduces a hard fork, ensure at least a quorum of the validator set has upgraded</li>
-        <li>Communicate T+2w Alfajores upgrade date</li>
-        <li>Tag released Docker image with <code>alfajores</code></li>
-      </ol>
-    </td>
-  </tr>
-  <tr>
-    <td>T+2w</td>
-    <td>
-      <ol>
-        <li>Confirm Alfajores users have upgraded without issues</li>
-        <li>If release introduces a hard fork, ensure at least a quorum of the validator set has upgraded</li>
-        <li>Communicate T+3w Mainnet upgrade date</li>
-        <li>Tag released Docker image with <code>mainnet</code> and <code>latest</code></li>
-      </ol>
-    </td>
-  </tr>
-  <tr>
-    <td>T+3w</td>
-    <td>
-      <ol>
-        <li>Confirm Mainnet users have upgraded without issues</li>
-        <li>If release introduces a hard fork, ensure at least a quorum of the validator set has upgraded</li>
-      </ol>
-    </td>
-  </tr>
-</table>
-
 ### Emergency Patches
 
 Bugs which affect the security, stability, or core functionality of the network may need to be released outside the standard release cycle. In this case, an emergency patch release should be created on top of all supported minor releases which contains the minimal change and corresponding test for the fix.
@@ -172,12 +92,4 @@ If the issue is exploitable and mitigations are not readily available, a patch s
 
 ## Vulnerability Disclosure
 
-Vulnerabilities in `celo-blockchain` releases should be disclosed according to the [security policy](https://github.com/celo-org/celo-blockchain/blob/master/SECURITY.md).
-
-## Dependencies
-
-None
-
-## Dependents
-
-None
+Vulnerabilities in `celo-blockchain` releases should be disclosed according to the [security policy](https://github.com/celo-org/celo-blockchain/blob/master/SECURITY.md)e


### PR DESCRIPTION
- Remove some specifics, such as release schedule or fixed distribution schedule.
- Remove mentions of developer signed artifacts
- Remove mentions of prebuilt binaries, as we currently don't supply those