### PR TITLE
Adds links to RPC node pages to our networks info page

### DIFF
--- a/docs/network/index.md
+++ b/docs/network/index.md
@@ -14,6 +14,7 @@ Overview of Celo Mainnet, Alfajores Testnet and Baklava Testnet.
 The production Celo network, Mainnet was previously known as the Release Candidate 1 network. Deployed by the Celo community starting 4/22/20, the network is currently working towards enabling the Celo stability mechansim. Much of the activity is being driven by the validator organisations that featured on the leaderboard of [The Great Celo Stake Off](https://forum.celo.org/t/the-great-celo-stake-off-the-details/136).
 
 - [Mainnet Network Block Explorer](http://explorer.celo.org/)
+- [Mainnet RPC Nodes](https://docs.celo.org/learn/developer-tools#hosted-nodes)
 - [Mainnet Network Status](https://stats.celo.org/)
 - [Mainnet Validator Explorer](https://validators.celo.org/)
 
@@ -24,6 +25,7 @@ The production Celo network, Mainnet was previously known as the Release Candida
 If you're a developer considering building on the Celo platform, or want to try out the [Celo Wallet](https://celo.org/build/wallet), start with **Alfajores**. You can [obtain a balance](https://celo.org/build/faucet) immediately and use it for experimenting with. The [Developer tutorials](/developer/) assume you are using Alfajores. The network is managed by cLabs, who operate all of its validators, and its software and deployed contracts will track mainnet.
 
 - [Alfajores Testnet Block Explorer](https://alfajores-blockscout.celo-testnet.org)
+- [Alfajores Testnet RPC Node](https://docs.celo.org/network/node/forno#alfajores-testnet)
 - [Alfajores Network Status](https://alfajores-celostats.celo-testnet.org)
 - [Alfajores Testnet Faucet](https://faucet.celo.org)
 - [Celo Wallet for Alfajores](https://celo.org/build/wallet)
@@ -41,6 +43,7 @@ Your use of the Alfajores Testnet is subject to the [Alfajores Testnet Disclaime
 If you're interested in operating one or more nodes that make up Celo's infrastructure, start with [Baklava](/network/baklava/). Baklava's validators and full nodes are operated by the community. It is intended to provide a venue to test new builds of the Celo Blockchain software, trial on-chain governance proposals, and for node operators to build operational best practices. Support for developers and users of the Wallet is not the primary focus.
 
 - [Baklava Network Block Explorer](https://baklava-blockscout.celo-testnet.org)
+- [Baklava Testnet RPC Node](https://docs.celo.org/network/node/forno#baklava-testnet)
 - [Baklava Network Status](https://baklava-celostats.celo-testnet.org)
 - [Baklava Faucet Request Form](https://forms.gle/JTYkMAJWTAUQp1sv9)
 


### PR DESCRIPTION
Adds links to various RPC node pages to our networks info page for mainnet, baklava, and alfajores.