### PR TITLE
Removes out-of-date developer events

### DIFF
--- a/docs/community/developer-events.md
+++ b/docs/community/developer-events.md
@@ -16,5 +16,3 @@ import TabItem from '@theme/TabItem';
 ## Hackathons
 
 - [Celo at ETHDenver](https://www.ethdenver.com)
-- [Mobile DeFi for the People ](https://mobiledefi.devpost.com/)
-- [Mobile Hackathon on GitCoin](https://gitcoin.co/hackathon/mobile-celo)


### PR DESCRIPTION
Found this page like this:

1. default CONTRIBUTING.md in celo-org Github org: [github.com/celo-org/.github/blob/1214ff0b824b65d726439867308b5548450b9836/CONTRIBUTING.md#contributing](https://github.com/celo-org/.github/blob/1214ff0b824b65d726439867308b5548450b9836/CONTRIBUTING.md#contributing)
2. Links to [docs.celo.org/community/contributing](https://docs.celo.org/community/contributing)
3. Links to [docs.celo.org/community/developer-events](https://docs.celo.org/community/developer-events)

<img width="573" alt="image" src="https://github.com/celo-org/docs/assets/46296830/7c4f94da-baab-4abf-9a2e-261319fe964d">


This page has out-of-date information