### PR TITLE
Update Particle Network

### DIFF
--- a/docs/developer/particle-network/index.md
+++ b/docs/developer/particle-network/index.md
@@ -5,7 +5,7 @@ description: Walkthrough on leveraging Particle Network's Wallet-as-a-Service on
 
 # Particle Network's Wallet-as-a-Service
 
-[**Particle Network**](https://particle.network) is the Intent-Centric, Modular Access Layer of Web3. With Particle's Wallet-as-a-Service, developers can curate a Web2-like user experience through modular and customizable embedded wallet components. Using [MPC-TSS for key management](https://blog.particle.network/particle-network-101-developer-experience-edition), Particle can streamline user onboarding via familiar Web2 accounts—such as Google accounts, email addresses, and phone numbers.
+[Particle Network](https://particle.network)'s Wallet Abstraction services enable universal, Web2-adjacent onboarding and interactions through social logins. Its core technology, [Smart Wallet-as-a-Service](https://blog.particle.network/announcing-our-smart-wallet-as-a-service-modular-stack-upgrading-waas-with-erc-4337) (WaaS) aims to onboard users into MPC-secured accounts supporting any chain. It also allows developers to offer an improved user experience through modular, fully customizable EOA/AA embedded wallets. Particle supports its Smart Wallet-as-a-Service through a Modular L1 powering chain abstraction, acting as a settlement layer across chains for a seamless multi-chain experience.
 
 Particle Network's Wallet-as-a-Service supports the Celo Mainnet and Alfajores Testnet through standard EOA-based social logins. Therefore, developers building on Celo can natively leverage Particle Network to onboard users into application-embedded wallets using social logins through various SDKs with direct Celo compatibility.
 


### PR DESCRIPTION
This PR applies a minor update to the page covering Particle Network (a social login provider on Celo) to shift around the opening blurb detailing Particle.

Particle Network is undergoing a slight rebranding, so this PR accounts for it with new positioning surrounding its placement and utility within the Celo ecosystem.