### PR TITLE
Adds USDC Adapter addresses on Mainnet and Alfajores

### DIFF
--- a/docs/protocol/transaction/erc20-transaction-fees.md
+++ b/docs/protocol/transaction/erc20-transaction-fees.md
@@ -43,7 +43,7 @@ USDC to be deployed. [Source](https://www.circle.com/blog/what-you-need-to-know-
 
 |  Name  | Token    | Adapter |
 | ------ | -------- | ------- |
-| `STBLTEST` | `0x780c1551C2Be3ea3B1f8b1E4CeDc9C3CE40da24E`  | `0xDB93874fE111F5a87Acc11Ff09Ee9450Ac6509AE`  |
+| `USDC` | `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B`  | `0x4822e58de6f5e485eF90df51C41CE01721331dC0`  |
 
 ##### Baklava (testnet)
 

--- a/docs/protocol/transaction/erc20-transaction-fees.md
+++ b/docs/protocol/transaction/erc20-transaction-fees.md
@@ -35,15 +35,15 @@ Adapters can also be used to query `balanceOf(address)` of an account, but it wi
 
 ##### Mainnet
 
-N/A
-
-USDC to be deployed. [Source](https://www.circle.com/blog/what-you-need-to-know-native-usdc-is-launching-on-celo).
+|  Name  | Token    | Adapter |
+| ------ | -------- | ------- |
+| `USDC` | [`0xcebA9300f2b948710d2653dD7B07f33A8B32118C`](https://celoscan.io/address/0xcebA9300f2b948710d2653dD7B07f33A8B32118C#code)  | [`0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B`](https://celoscan.io/address/0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B#code)  |
 
 ##### Alfajores (testnet)
 
 |  Name  | Token    | Adapter |
 | ------ | -------- | ------- |
-| `USDC` | `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B`  | `0x4822e58de6f5e485eF90df51C41CE01721331dC0`  |
+| `USDC` | [`0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B`](https://alfajores.celoscan.io/address/0x2f25deb3848c207fc8e0c34035b3ba7fc157602b#code)  | [`0x4822e58de6f5e485eF90df51C41CE01721331dC0`](https://alfajores.celoscan.io/address/0x4822e58de6f5e485eF90df51C41CE01721331dC0#code)  |
 
 ##### Baklava (testnet)
 


### PR DESCRIPTION
## Description

The [governance proposal](https://celo.stake.id/#/proposal/168) has passed and USDC is a whitelisted fee currency.

## Changes

- Adds USDC Adapter addresses on Mainnet and Alfajores with links to Celoscan
- Removes `STBLTEST`, since the token is not of use anymore.

## Other

For future reference, it is known that there is a repeated address. On mainnet it's the adapter, and on alfajores it's the token. That’s because Circle deployed the same proxy bytecode from the same account. It's not a problem, I'm just acknowledging this is known.

- Mainnet
  - Token
    - Contract Name: FiatTokenProxy
    - Contract address: [0xcebA9300f2b948710d2653dD7B07f33A8B32118C](https://celoscan.io/address/0xcebA9300f2b948710d2653dD7B07f33A8B32118C#code)
  - Adapter:
    - Contract Name: FiatTokenFeeAdapterProxy
    - Contract address: [0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B](https://celoscan.io/address/0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B#code) :point_left: same address
- Alfajores
  - Token:
    - Contract Name: FiatTokenProxy
    - Contract address: [0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B](https://alfajores.celoscan.io/address/0x2f25deb3848c207fc8e0c34035b3ba7fc157602b#code) :point_left: same address
  - Adapter:
    - Contract Name: FiatTokenFeeAdapterProxy
    - Contract address: [0x4822e58de6f5e485eF90df51C41CE01721331dC0](https://alfajores.celoscan.io/address/0x4822e58de6f5e485eF90df51C41CE01721331dC0#code)