### PR TITLE
Update CLI docs script

### DIFF
--- a/docs/cli/exchange.md
+++ b/docs/cli/exchange.md
@@ -6,7 +6,6 @@ Exchange Celo Dollars and CELO via Mento
 * [`celocli exchange:celo`](#celocli-exchangecelo)
 * [`celocli exchange:dollars`](#celocli-exchangedollars)
 * [`celocli exchange:euros`](#celocli-exchangeeuros)
-* [`celocli exchange:gold`](#celocli-exchangegold)
 * [`celocli exchange:reals`](#celocli-exchangereals)
 * [`celocli exchange:show`](#celocli-exchangeshow)
 * [`celocli exchange:stable`](#celocli-exchangestable)
@@ -126,48 +125,6 @@ EXAMPLES
 ```
 
 _See code: [src/commands/exchange/euros.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/exchange/euros.ts)_
-
-## `celocli exchange:gold` {#celocli-exchangegold}
-
-Exchange CELO for StableTokens via the stability mechanism. *DEPRECATION WARNING* Use the "exchange:celo" command instead
-
-```
-USAGE
-  $ celocli exchange:gold --from <value> --value <value> [--gasCurrency <value>]
-    [--globalHelp] [--forAtLeast <value>] [--stableToken
-    cUSD|cusd|cEUR|ceur|cREAL|creal]
-
-FLAGS
-  --forAtLeast=10000000000000000000000                      [default: 0] Optional, the
-                                                            minimum value of
-                                                            StableTokens to receive in
-                                                            return
-  --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) The address with
-                                                            CELO to exchange
-  --gasCurrency=0x1234567890123456789012345678901234567890  Use a specific gas currency
-                                                            for transaction fees
-                                                            (defaults to CELO if no gas
-                                                            currency is supplied). It
-                                                            must be a whitelisted token.
-  --globalHelp                                              View all available global
-                                                            flags
-  --stableToken=<option>                                    [default: cusd] Name of the
-                                                            stable to receive
-                                                            <options: cUSD|cusd|cEUR|ceu
-                                                            r|cREAL|creal>
-  --value=10000000000000000000000                           (required) The value of CELO
-                                                            to exchange for a
-                                                            StableToken
-
-DESCRIPTION
-  Exchange CELO for StableTokens via the stability mechanism. *DEPRECATION WARNING* Use
-  the "exchange:celo" command instead
-
-EXAMPLES
-  gold --value 5000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d
-
-  gold --value 5000000000000 --forAtLeast 100000000000000 --from 0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d --stableToken cUSD
-```
 
 ## `celocli exchange:reals` {#celocli-exchangereals}
 

--- a/docs/cli/governance.md
+++ b/docs/cli/governance.md
@@ -314,8 +314,9 @@ Submit a governance proposal
 ```
 USAGE
   $ celocli governance:propose --jsonTransactions <value> --deposit <value> --from
-    <value> --descriptionURL <value> [--gasCurrency <value>] [--globalHelp] [--force]
-    [--noInfo] [--afterExecutingProposal <value> | --afterExecutingID <value>]
+    <value> --descriptionURL <value> [--gasCurrency <value>] [--globalHelp] [--for
+    <value> --useMultiSig] [--force] [--noInfo] [--afterExecutingProposal <value> |
+    --afterExecutingID <value>]
 
 FLAGS
   --afterExecutingID=<value>                                Governance proposal
@@ -329,6 +330,8 @@ FLAGS
   --descriptionURL=<value>                                  (required) A URL where
                                                             further information about
                                                             the proposal can be viewed
+  --for=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d          Address of the multi-sig
+                                                            contract
   --force                                                   Skip execution check
   --from=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d         (required) Proposer's
                                                             address
@@ -343,12 +346,16 @@ FLAGS
                                                             transactions
   --noInfo                                                  Skip printing the proposal
                                                             info
+  --useMultiSig                                             True means the request will
+                                                            be sent through multisig.
 
 DESCRIPTION
   Submit a governance proposal
 
 EXAMPLES
-  propose --jsonTransactions ./transactions.json --deposit 10000 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33
+  propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33
+
+  propose --jsonTransactions ./transactions.json --deposit 10000e18 --from 0x5409ed021d9299bf6814279a6a1411a7e866a631  --useMultiSig --for 0x6c3dDFB1A9e73B5F49eDD46624F4954Bf66CAe93 --descriptionURL https://gist.github.com/yorhodes/46430eacb8ed2f73f7bf79bef9d58a33
 ```
 
 _See code: [src/commands/governance/propose.ts](https://github.com/celo-org/developer-tooling/tree/master/packages/cli/src/commands/governance/propose.ts)_

--- a/scripts/copy-generated-docs.sh
+++ b/scripts/copy-generated-docs.sh
@@ -1,4 +1,4 @@
 git submodule init
 git submodule update
-cp -R ./submodules/developer-tooling/packages/docs/command-line-interface/* ./docs/cli/
+cp -R ./submodules/developer-tooling/docs/command-line-interface/* ./docs/cli/
 yarn write-heading-ids docs/cli/*

--- a/scripts/copy-generated-docs.sh
+++ b/scripts/copy-generated-docs.sh
@@ -1,4 +1,5 @@
 git submodule init
 git submodule update
+git submodule foreach git pull origin master
 cp -R ./submodules/developer-tooling/docs/command-line-interface/* ./docs/cli/
 yarn write-heading-ids docs/cli/*

--- a/scripts/copy-generated-docs.sh
+++ b/scripts/copy-generated-docs.sh
@@ -1,5 +1,4 @@
 git submodule init
 git submodule update
-git submodule foreach git pull origin master
 cp -R ./submodules/developer-tooling/docs/command-line-interface/* ./docs/cli/
 yarn write-heading-ids docs/cli/*


### PR DESCRIPTION
## Description

This PR: 
1. updates the docs path to match the changes made the `celo-org/developer-tooling` in this PR: https://github.com/celo-org/developer-tooling/pull/238

## Related

- Related https://github.com/celo-org/developer-tooling/pull/238
- Fixes https://github.com/celo-org/developer-tooling/issues/206 (by product of PR)


## Tested

Yes, running `yarn install` successful ran the `postinstall` hook, and fetched the latest commit from the `celo-org/developer-tooling` repp (see https://github.com/celo-org/docs/pull/1312/commits/eabaa2f4c0dd27aaa78b64d6db10c8fc8abb5888).