### PR TITLE
feat: add a CI workflow for detecting broken links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,24 @@
+name: Check Broken Links
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * SUN" # at 5am on Sundays
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: bug, automated issue


### PR DESCRIPTION
Set up following the instructions at https://github.com/marketplace/actions/lychee-broken-link-checker.

The workflow will scan the repository weekly for broken links and create issues if it finds any.