### PR TITLE
chore: update links.yml config

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -25,7 +25,6 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           args: >-
-            --base .
             --verbose
             --no-progress
             --cache --max-cache-age 1d

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -8,12 +8,32 @@ on:
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    
     steps:
+      - name: Restore lychee cache
+        id: restore-cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
       - uses: actions/checkout@v4
 
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1
+        with:
+          args: >-
+            --base .
+            --verbose
+            --no-progress
+            --cache --max-cache-age 1d
+            './**/*.md'
+            './**/*.html'
+            './**/*.rst'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -29,9 +29,11 @@ jobs:
             --verbose
             --no-progress
             --cache --max-cache-age 1d
-            './**/*.md'
             './**/*.html'
+            './**/*.js'
+            './**/*.md'
             './**/*.rst'
+            './**/*.tsx'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -36,6 +36,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+      - name: Check Output Size and Exit If Too Large
+        id: wc
+        shell: bash
+        run: |
+          # See https://github.com/peter-evans/create-issue-from-file/issues/1049
+          if [ "$(wc -m < ./lychee/out.md)" -gt 65536 ]; then
+            echo "Link Checker output is too big (> 65536 characters) for a GitHub Issue descriptions."
+            exit 1
+          fi
+          
+  createIssue:
+    runs-on: ubuntu-latest
+    needs: linkChecker
+
+    steps:  
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v5


### PR DESCRIPTION
Running the workflow manually (see https://github.com/celo-org/docs/actions/runs/9679044164/job/26704145144) fails on creating a ticket because the body is too big (see https://github.com/peter-evans/create-issue-from-file/issues/1049).

This PR aims to reduce the amount of failures to be reported by
- adding caching and a GITHUB_TOKEN as per instructions at https://lychee.cli.rs/github_action_recipes/caching/#caching-in-github-actions for speed
- removing the progression indication (recommended for CI)
- adding verbose logging