### PR TITLE
Add mainnet migration process overview

### DIFF
--- a/docs/cel2/faq.md
+++ b/docs/cel2/faq.md
@@ -7,7 +7,7 @@ description: Frequently Asked Questions about Cel2
 
 ### How do I run a node or upgrade an existing node?
 
-- [Celo L1 → Celo L2 Operator Guide](https://specs.celo.org/l2_operator_guide.html) and related assets:
+- [Celo L1 → Celo L2 Operator Guide](/docs/cel2/l2-operator-guide.md) and related assets:
   - [Full migrated chaindata](https://storage.googleapis.com/cel2-rollup-files/dango/dango-migrated-datadir.tar.zst)
   - [Rollup deploy config](https://storage.googleapis.com/cel2-rollup-files/dango/config.json)
   - [L1 contract addresses](https://storage.googleapis.com/cel2-rollup-files/dango/deployment-l1.json)

--- a/docs/cel2/l2-operator-guide.md
+++ b/docs/cel2/l2-operator-guide.md
@@ -277,6 +277,73 @@ Start the Celo L2 execution client with an empty datadir.
 - Start Celo node with fully synced datadir in archive mode.
 - Start the Celo L2 execution client with a fully synced and migrated Celo datadir and additionally provide a flag with the RPC API address of the Celo node (this flag will be used to proxy any requests needing execution to the Celo node)
 
+## Mainnet Migration Process Overview (WIP)
+
+Note this section is subject to change and intended for illustrative purposes only.
+
+### Stopping the L1 Celo network
+
+A new version of `celo-blockchain` will be released that allows the flag`--l2migrationbock` to be passed, specifying the block number of the first L2 block (i.e. the block immediately after the last block of the Celo network as an L1). Nodes ran with this flag will stop producing, inserting and sharing blocks when the block number before `--l2migrationblock` is inserted.
+
+When this version of `celo-blockchain` is released and a migration block number has been chosen, node operators will be asked to upgrade and pass in the correct block number when restarting their node.
+
+### Starting an L2 node
+
+As is detailed in other parts of this guide, node operators who wish to run an L2 node will have two options.
+
+1. Perform a migration of the l1 chaindata. This option is required for nodes running in full or archive mode and is a more involved process.
+2. Start an L2 node with snap sync. This option does not require running the migration script.
+
+The rest of this section applies only to option 1.
+
+### Pre-migration
+
+~48 hours before the migration block, node operators will need to run a pre-migration script. This script migrates the majority of the chaindata in advance so that the full migration can quickly complete the migration on top of the latest state when the migration block is reached. (Method of distributing the migration script is TBD, right now we build and run from source).
+
+1. Create a snapshot of the node's chaindata directory. This is a subdirectory of the node's datadir.
+    - Do not run the migration script on a datadir that is actively being used by a node.
+    - In order to ensure liveness of the network, please do not stop your node to perform the migration.
+    - Make sure you have at least enough disk space to store double the size of the snapshot. As you will be storing both the old and new (migrated) chaindata.
+2. Run the pre-migration script.
+
+```bash
+celo-migrate pre --old-db /path/to/old/datadir/chaindata --new-db /path/to/new/datadir/chaindata
+```
+
+- `old-db` should be the path to the chaindata snapshot.
+- `new-db` should be the path where you want the l2 chaindata to be written.
+- Please run the pre-migration script at least 24 hours before the migration block so that there is time to trouble shoot any issues.
+- Ensure the pre-migration script completes successfully (this should be clear from the logs). If it does not, please reach out for assistance.
+- Keep the `new-db` as is until the full migration script is run. If this data is corrupted or lost, the full migration may fail or take a very long time to complete.
+
+### Full migration
+
+Your node will stop adding blocks immediately before the block passed as `--l2migrationblock`. That is, the last block added will be `l2migrationblock - 1`, and the first block of the l2 will `l2migrationblock`. When your node stops adding blocks, you may shut it down.
+
+NOTE: Do not run the migration script on a datadir that is actively being used by a node even if it has stopped adding blocks.
+
+1. Run the full migration script
+
+```bash
+celo-migrate full  --old-db /path/to/old/datadir/chaindata --new-db /path/to/new/datadir/chaindata --deploy-config /path/to/deploy-config.json --l1-deployments /path/to/l1-deployments.json --l1-rpc <ETHEREUM_RPC_URL> --l2-allocs /path/to/l2-allocs.json --outfile.rollup-config /path/to/rollup-config.json --outfile.genesis /path/to/genesis.json
+```
+
+- `old-db` should be the path to the chaindata snapshot or the chaindata of your stopped node.
+- `new-db` should be the path where you want the l2 chaindata to be written. This should be the same path as in the pre-migration script, otherwise all the work done in the pre-migration will be lost.
+- `deploy-config` should be the path to the JSON file that was used for the l1 contracts deployment. This will be distributed by cLabs.
+- `l1-deployments` should be the path to the L1 deployments JSON file, which is the output of running the bedrock contracts deployment for the given 'deploy-config'. This will be distributed by cLabs.
+- `l1-rpc` should be the rpc url of an l1 (i.e. Ethereum) node.
+- `l2-allocs` should be the path to the JSON file defining necessary state modifications that will be made during the full migration. This will be distributed by cLabs.
+- `outfile.rollup-config` should be the path where you want the rollup-config.json file to be written by the migration script. You will need to pass this file when starting the l2 node.
+- `outfile.genesis` should be the path where you want the `genesis.json` file to be written by the migration script. Any node wishing to snap sync on the L2 chain will need this file.
+
+- Ensure the full migration script completes successfully (this should be clear from the logs). If it does not, please reach out for assistance.
+
+### Start L2 Node
+
+- Start the l2 node using the migrated chaindata written to the new-db path.
+- Exact command is TBD. Right now we run both op-node and op-geth from source seperately and pass in a bunch of flags to each. We will provide a more user friendly way to start the entire node.
+
 ## A history of Celo block structure
 
 Celo started as a fork of go-ethereum but initially made some significant changes to the structure of headers and blocks because it was operating with a proof of stake consensus mechanism.


### PR DESCRIPTION
Adds a general illustrative overview of the steps for the mainnet l2 migration to the L1 -> L2 Operator guide 