### PR TITLE
Add Gas.zip to Token Bridges in Docs

### DIFF
--- a/docs/protocol/bridge/index.md
+++ b/docs/protocol/bridge/index.md
@@ -15,8 +15,9 @@ Be sure you understand and review the risks pages when bridging assets between c
 
 :::
 
-## Token bridges
+## Token Bridges
 
+- [Gas.zip (Gas Reloading)](https://gas.zip)
 - [SmolRefuel (Gassless Bridging)](https://smolrefuel.com/?outboundChain=42220)
 - [Squid Router V2](https://v2.app.squidrouter.com/)
 - [Portal (Wormhole)](https://www.portalbridge.com/#/transfer)


### PR DESCRIPTION
Added Gas.zip for as native gas reloading option from over 18+ EVM chains & Solana to CELO native 