### PR TITLE
Add migration-block flag to migrate instructions

### DIFF
--- a/docs/cel2/l2-operator-guide.md
+++ b/docs/cel2/l2-operator-guide.md
@@ -307,6 +307,7 @@ docker run -it --rm \
     --l1-rpc https://ethereum-holesky-rpc.publicnode.com \
     --outfile.rollup-config /path/to/rollup.json \
     --outfile.genesis /path/to/genesis.json
+    --migration-block-time=1727339320
 ```
 
 - `old-db` must be the path to the chaindata snapshot or the chaindata of your stopped node.


### PR DESCRIPTION
The block time affects the block hash, without the flag the migration script uses the current time, so everyone's block hash will differ.