### PR TITLE
add warning and workaround for Remix error

### DIFF
--- a/blog/04-01-2023-How-To-Build-A-Multi-Signature-Wallet/How-To-Build-A-Multi-Signature-Wallet-Contract.md
+++ b/blog/04-01-2023-How-To-Build-A-Multi-Signature-Wallet/How-To-Build-A-Multi-Signature-Wallet-Contract.md
@@ -1,6 +1,6 @@
 ---
 title: How To Build A Multi Signature Wallet Contract That Requires Multiple Approvals For Transactions On Celo
-description: In this tutorial, we will walk through the process of building a multi-signature wallet contract using Solidity and remix ide
+description: In this tutorial, we will walk through the process of building a multi-signature wallet contract using Solidity and Remix IDE
 authors:
   - name: ✍️ Jonathan Iheme
     url: https://github.com/4undRaiser

--- a/docs/developer/deploy/remix.md
+++ b/docs/developer/deploy/remix.md
@@ -15,15 +15,29 @@ The [Remix IDE](https://remix-project.org/) is an open-source web and desktop ap
 
 In this guide, you will learn to deploy a smart contract on Celo using [remix.ethereum.org](http://remix.ethereum.org).
 
+:::warning
+For Celo L1 Remix does not support Solidity compiler version `0.8.20` and above for EVM versions above **Paris**. If you try to deploy a smart contract with a higher version, you will receive this error message:
+
+
+```bash
+Gas estimation errored with the following message (see below). The transaction execution will likely fail. Do you want to force sending?
+
+invalid opcode: opcode 0x5f not defined
+The EVM version used by the selected environment is not compatible with the compiler EVM version.
+```
+
+A **workaround** is to go into the advanced settings for the compiler in Remix and choose Paris as the EVM version.
+
+For Alfajores L2 everything should be working as on every other EVM compatible chain.
+:::
+
 :::tip
 
 To learn more about the features available to you as a smart contract developer with Remix, visit the [Remix documentation](https://remix-ide.readthedocs.io/en/latest/).
 
 :::
 
-:::warning
-Remix does not support Solidity compiler version `0.8.20` and above specifically for the Celo network. You can alternatively use [Atlas IDE](https://app.atlaszk.com/ide)
-:::
+
 
 ## Create a Smart Contract
 

--- a/docs/developer/sdks/celo-sdks.md
+++ b/docs/developer/sdks/celo-sdks.md
@@ -16,5 +16,5 @@ Because Celo is compitable with Ethereum any ethereum package can be used with C
 - [viem](../viem/index.md)
 - [ContractKit](../contractkit/index.md)
 - [thirdweb SDK](../thirdweb-sdk/index.md)
-- [Rainbowkit-Celo](../rainbowkit-celo/index.md)
+- [Rainbowkit](../rainbowkit-celo/index.md)
 - [web3](../web3/index.md)


### PR DESCRIPTION
Currently when trying deploy a smart contract with a Solidity Version higher than 0.8.20 on Celo Mainnet, you are getting the error below. This is related to missing opcodes that are needed in EVM versions higher than EVM version Paris. As Alfajores has already been upgraded to an L2 this can be ignored. This is Celo L1 specific. 

```bash
Gas estimation errored with the following message (see below). The transaction execution will likely fail. Do you want to force sending?

invalid opcode: opcode 0x5f not defined
The EVM version used by the selected environment is not compatible with the compiler EVM version.
```

In this PR we have added this information, including a workaround.

With the migration to an L2 this warning can be removed as it will be resolved.

