### PR TITLE
fix typos in documentation files

### DIFF
--- a/docs/cli/exchange.md
+++ b/docs/cli/exchange.md
@@ -218,7 +218,7 @@ FLAGS
   --globalHelp                                              View all available global
                                                             flags
   --stableToken=<option>                                    Name of the stable token to
-                                                            be transfered
+                                                            be transferred
                                                             <options: cUSD|cusd|cEUR|ceu
                                                             r|cREAL|creal>
   --value=10000000000000000000000                           (required) The value of

--- a/docs/cli/transfer.md
+++ b/docs/cli/transfer.md
@@ -243,7 +243,7 @@ FLAGS
   --globalHelp                                              View all available global
                                                             flags
   --stableToken=<option>                                    Name of the stable to be
-                                                            transfered
+                                                            transferred
                                                             <options: cUSD|cusd|cEUR|ceu
                                                             r|cREAL|creal>
   --to=0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d           (required) Address of the

--- a/docs/general/index.md
+++ b/docs/general/index.md
@@ -46,7 +46,7 @@ Celo is optimized for mobile devices, making blockchain accessible to billions o
 Celo is committed to environmental sustainability, offsetting more carbon than it produces.
 
 - **Proof-of-Stake**: Celo uses an energy-efficient consensus mechanism that avoids energy-intensive mining, reducing its carbon footprint.
-- **Ultragreen-Money**: A portion of every transaction feengoes towards carbon offsetting and sustainability projects, supporting environmental efforts with every transaction.
+- **Ultragreen-Money**: A portion of every transaction fee goes towards carbon offsetting and sustainability projects, supporting environmental efforts with every transaction.
 
 ## Understanding the Celo Ecosystem
 

--- a/docs/protocol/plumo.md
+++ b/docs/protocol/plumo.md
@@ -54,7 +54,7 @@ The Plumo MPC setup is broken up into two phases:
 - Phase 2 - Plumo circuit
   - In this phase, the participants contribute to the Plumo circuit keys, which would be used by provers to create proofs and verifiers to verify them.
 
-Phase 1 will take place starting early December 2020, and continue until January 2021. It will consist of multiple rounds of 6–10 contributors each running the Plumo setup for approximately 36 hours. While much of the activity is passive and involves simply running the computation continuously, contributors should not expect to use their machines for other intensive activies through the duration of the setup.
+Phase 1 will take place starting early December 2020, and continue until January 2021. It will consist of multiple rounds of 6–10 contributors each running the Plumo setup for approximately 36 hours. While much of the activity is passive and involves simply running the computation continuously, contributors should not expect to use their machines for other intensive activities through the duration of the setup.
 
 Phase 2 will commence roughly a month after Phase 1.
 
@@ -74,7 +74,7 @@ You can run the contributor software locally or on cloud VMs, but desktop machin
 - Operating system: Linux, macOS, Windows
 - Recommended internet connection speed: 10Mbit upload
 
-With these kind of machines, participiation in the setup should take around 30 hours, potentially a bit more or much less, depending on your specific hardware and internet connection.
+With these kind of machines, participation in the setup should take around 30 hours, potentially a bit more or much less, depending on your specific hardware and internet connection.
 
 ## Running the Setup
 
@@ -129,7 +129,7 @@ cLabs is running the coordinator server, which has a list of approved participan
 
 - You will be asked for your passphrase - enter the same one from earlier.
   - Follow the same process from earlier when prompted for additional entropy.
-- Wait until you see 0/256 on the progress bar. This means that your contribution has started, and you are succesfully running the contributor binary.
+- Wait until you see 0/256 on the progress bar. This means that your contribution has started, and you are successfully running the contributor binary.
 
 Once this is running, you can leave the machine running -- no direct action is needed. This will run for about ~36 hours, after which the software will terminate running and you will have finished contributing to the Plumo setup!
 

--- a/docs/wallet/index.md
+++ b/docs/wallet/index.md
@@ -44,7 +44,7 @@ MiniPay is a non-custodial 2MB wallet that allows users to send and receive stab
 
 ### [Othello Wallet](https://celowallet.app/setup)
 
-Othello Wallet (formally know as CeloWallet) is a lightweight, mobile-friendly wallet for both web and desktop. It supports core Celo functionality like payments, exchanges, staking, and governance.
+Othello Wallet (formally known as CeloWallet) is a lightweight, mobile-friendly wallet for both web and desktop. It supports core Celo functionality like payments, exchanges, staking, and governance.
 
 - Platforms: Web, MacOS, Linux, Windows
 - Maintainers: [J M Rossy](https://twitter.com/RossyWrote)
@@ -170,5 +170,5 @@ Strictly speaking, Wallet Connect is not a wallet; it is an open protocol for co
 
 ### [El Dorado](https://eldorado.io/)
 
-- Countries: Argentina, Brazilm, Colombia, Panama, Peru, Venezuela
+- Countries: Argentina, Brazil, Colombia, Panama, Peru, Venezuela
 - Platforms: Android, iOS


### PR DESCRIPTION
### Summary of Changes

**docs/cli/exchange.md**
- `be transfered` → `be transferred`

**docs/cli/transfer.md**
- `be transfered` → `be transferred`

**docs/general/index.md**
- `feegoes` → `fee goes`

**docs/protocol/plumo.md**
- `activites` → `activities`
- `participiation` → `participation`
- `succesfully` → `successfully`

**docs/wallet/index.md**
- `know` → `known`
- `Brazilm` → `Brazil`