### PR TITLE
Update l2-operator-guide.md: Include sequencer http address

### DIFF
--- a/docs/cel2/l2-operator-guide.md
+++ b/docs/cel2/l2-operator-guide.md
@@ -326,6 +326,8 @@ docker run -d \
     --snapshot=true \
     --maxpeers=60 \
     --port=30303 \
+    --rollup.sequencerhttp=https://sequencer.alfajores.celo-testnet.org \
+    --rollup.disabletxpoolgossip=true \
     --authrpc.addr=127.0.0.1 \
     --authrpc.port=8551 \
     --authrpc.jwtsecret=/datadir/jwt.hex \


### PR DESCRIPTION
Include sequencer rpc address so op-geth can forward transactions to it.