### PR TITLE
Update evm-tools.md

### DIFF
--- a/docs/developer/evm-tools.md
+++ b/docs/developer/evm-tools.md
@@ -147,7 +147,7 @@ A guide to available tools, components, patterns, and platforms for developing a
 - [Eventeum](https://github.com/ConsenSys/eventeum) - A bridge between Ethereum smart contract events and backend microservices, written in Java by Kauri
 - [Ethereumex](https://github.com/mana-ethereum/ethereumex) - Elixir JSON-RPC client for the Ethereum blockchain
 - [Ethereum-jsonrpc-gateway](https://github.com/HydroProtocol/ethereum-jsonrpc-gateway) - A gateway that allows you to run multiple Ethereum nodes for redundancy and load-balancing purposes. Can be run as an alternative to (or on top of) Infura. Written in Golang.
-- [EthContract](https://github.com/AgileAlpha/eth_contract) - A set of helper methods to help query ETH smart contracts in Elixir
+- [EthContract](https://github.com/zyield/eth_contract) - A set of helper methods to help query ETH smart contracts in Elixir
 - [Ethereum Contract Service](https://github.com/mesg-foundation/service-ethereum-contract) - A MESG Service to interact with any Ethereum contract based on its address and ABI.
 - [Ethereum Service](https://github.com/mesg-foundation/service-ethereum) - A MESG Service to interact with events from Ethereum and interact with it.
 - [Marmo](https://marmo.io/) - Python, JS, and Java SDK for simplifying interactions with Ethereum. Uses relayers to offload transaction costs to relayers.


### PR DESCRIPTION
The old url was using a github username which was not available on github.com

https://github.com/AgileAlpha

But when we access the repository url https://github.com/AgileAlpha/eth_contract it redirects to https://github.com/zyield/eth_contract
This happens when user change their username.

This PR, updates the correct URL.