### PR TITLE
update to nav bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,12 +104,12 @@ module.exports = {
         },
         {
           to: "build/",
-          label: "Get Started",
+          label: "Build on Celo",
           position: "left",
         },
         {
           to: "developer/",
-          label: "Build on Celo",
+          label: "Tooling",
           position: "left",
         },
         {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -99,7 +99,7 @@ export default function HomePage(): JSX.Element {
               <div className="w-2/3 flex flex-col justify-between h-full">
                 <span className="text-3xl font-semibold">
                   <Translate id="home2.section1.box1">
-                    Get started with Celo Composer CLI
+                    Quickstart with Celo Composer
                   </Translate>
                 </span>
                 {buildKnowMoreButton("/developer/deploy")}


### PR DESCRIPTION
Changes made:

Section Title “Build on Celo” can be misleading and will make it hard to find information about wallets and bridges. Better “Tooling”

Section Title “Get Started” should be changed to “Build on Celo” as it has Celo specific tutorials etc

On the startpage instead of Get started with Celo Composer CLI, lets say “Quickstart” as people who don’t know what the Celo composer is, will not understand that it’s a starterkit