### PR TITLE
Link to RPC diff description in specs

### DIFF
--- a/docs/cel2/whats-changed/l1-l2.md
+++ b/docs/cel2/whats-changed/l1-l2.md
@@ -77,7 +77,7 @@ Old blocks, transactions, receipts and logs will still be accessible via the RPC
 
 In general the changes involve additional extra unset fields that have been added upstream but were not present on historical Celo L1 objects, and the removal of some unnecessarily set fields on Celo L1 objects.
 
-For in depth details of what is changed see here - (TODO add section in specs covering this)
+For in depth details of what is changed see the [RPC change description in the specs](https://specs.celo.org/l2_migration.html?search=#changes-for-json-rpc-users).
 
 ### Pre-transition execution and state access
 


### PR DESCRIPTION
The relevant information is added in https://github.com/celo-org/specs/pull/89

Closes https://github.com/celo-org/specs/issues/84?reload=1