### PR TITLE
I mistakenly did not remove the trailing d on these links

### DIFF
--- a/docs/cel2/operators/run-node.md
+++ b/docs/cel2/operators/run-node.md
@@ -87,8 +87,8 @@ The following sections contain all infromation required to set up your node from
 
 #### Baklava
 
-- [Final Celo L1 chaindata](https://storage.googleapis.com/cel2-rollup-files/baklava/baklava-l1-final.tar.zstd)
-- [Full migrated chaindata](https://storage.googleapis.com/cel2-rollup-files/baklava/baklava-migrated-datadir.tar.zstd)
+- [Final Celo L1 chaindata](https://storage.googleapis.com/cel2-rollup-files/baklava/baklava-l1-final.tar.zst)
+- [Full migrated chaindata](https://storage.googleapis.com/cel2-rollup-files/baklava/baklava-migrated-datadir.tar.zst)
 - [Rollup deploy config](https://storage.googleapis.com/cel2-rollup-files/baklava/config.json)
 - [L1 contract addresses](https://storage.googleapis.com/cel2-rollup-files/baklava/deployment-l1.json)
 - [L2 allocs](https://storage.googleapis.com/cel2-rollup-files/baklava/l2-allocs.json)


### PR DESCRIPTION
While these links will still work because we made a copy of the files on the server, they are inconsistent with the alfajores links that use .zst so we should use that.