### PR TITLE
Add mainnet pre-migration information

### DIFF
--- a/docs/cel2/operators/migrate-node.md
+++ b/docs/cel2/operators/migrate-node.md
@@ -63,6 +63,9 @@ blocks at the block immediately preceding the hardfork block.
 * Baklava *28308600*
   * Celo L1 client: [celo-blockchain v1.8.8](https://github.com/celo-org/celo-blockchain/releases/tag/v1.8.8).
   * Docker image `us-docker.pkg.dev/celo-org/us.gcr.io/geth-all:1.8.8`
+* Mainnet *31056500*
+  * Celo L1 client: [celo-blockchain v1.8.9](https://github.com/celo-org/celo-blockchain/releases/tag/v1.8.9).
+  * Docker image `us-docker.pkg.dev/celo-org/us.gcr.io/geth-all:1.8.9`
 
 ### Run the pre-migration tool
 


### PR DESCRIPTION
Block number taken from https://forum.celo.org/t/returning-home-to-ethereum-the-launch-of-celo-l2-mainnet/10466

Preview at https://deploy-preview-1734--celo-docs.netlify.app/cel2/operators/migrate-node#before-the-migration