### PR TITLE
Revert "link-checker: For now only lint `cel2` (#1720)"

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -29,7 +29,11 @@ jobs:
             --verbose
             --no-progress
             --cache --max-cache-age 1d
-            './docs/cel2/**/*.html'
+            './**/*.html'
+            './**/*.js'
+            './**/*.md'
+            './**/*.rst'
+            './**/*.tsx'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
This reverts commit 7412bd2e35b25b6826c0c331029104a762367961.