### PR TITLE
Express all Mainnet migration dates in UTC

### DIFF
--- a/docs/cel2/index.md
+++ b/docs/cel2/index.md
@@ -85,7 +85,7 @@ The core dev team froze all feature development by mid-October and underwent a t
 
 Using the final audited release, the Celo validator community will perform a dry run of the L2 upgrade on the Baklava network.
 
-#### 25th March, 2025: Celo L2 Mainnet Launch
+#### 26th March, 2025 (3:00 AM UTC): Celo L2 Mainnet Launch
 
 Following a successful Baklava upgrade, the Celo L2 Mainnet will officially go live. All nodes must be updated by this time to avoid disruption.
 

--- a/docs/cel2/notices/l2-migration.md
+++ b/docs/cel2/notices/l2-migration.md
@@ -109,7 +109,7 @@ Once the pre-migration is complete, you can start your L1 node again. The pre-mi
 ### Mainnet
 
 * Block number: `31056500`
-* Date: March 25, 2025
+* Date: March 26, 2025 (3:00 AM UTC)
 * Minimum `celo-blockchain` version: [v1.8.9](https://github.com/celo-org/celo-blockchain/releases/tag/v1.8.9)
 * `op-geth`: [celo-v2.0.0](https://github.com/celo-org/op-geth/releases/tag/celo-v2.0.0)
 * `op-node`: [celo-v2.0.0](https://github.com/celo-org/optimism/releases/tag/celo-v2.0.0)

--- a/docs/cel2/notices/l2-migration.md
+++ b/docs/cel2/notices/l2-migration.md
@@ -5,7 +5,7 @@ This page will be kept updated with key information about the hardfork.
 
 * The Alfajores testnet has been migrated on block **26384000**, September 26, 2024.
 * The Baklava testnet has been migrated on block **28308600**, February 20, 2025.
-* Mainnet will be migrated on block **31056500**, March 25, 2025.
+* Mainnet will be migrated on block **31056500**, March 26, 2025, 3:00 AM UTC.
 
 :::
 


### PR DESCRIPTION
This avoids confusion. Communication is split between March 25th in UTC and March 26th in PST.