### PR TITLE
Move Thirdweb along with examples

### DIFF
--- a/docs/build/build-with-thirdweb/one-click-deploy.md
+++ b/docs/build/build-with-thirdweb/one-click-deploy.md
@@ -1,5 +1,5 @@
 ---
-title: One-Click Quickstart
+title: One-Click Deploy
 ---
 
 Create and deploy Web3 apps effortlessly with Thirdweb and Celo. 
@@ -10,8 +10,9 @@ Create and deploy Web3 apps effortlessly with Thirdweb and Celo.
 
 By the end of this tutorial, you will:
 
-* Be able to transfer Celo to another address
-* Have a mintable **NFT Drop**.
+- Be able to transfer Celo to another address
+- Have a mintable **NFT Drop**.
+- Build an **NFT gallery**
 
 ## Prerequisites
 
@@ -20,8 +21,8 @@ By the end of this tutorial, you will:
 
 ## Fund Your Wallet  
 
-1. Ensure you have sufficient funds to cover the transaction fees.  
-2. Visit the [Alfajores Faucet](https://faucet.celo.org/alfajores) to claim test tokens using a wallet address. ***Remember to claim only what you need.***
+1. Ensure there are sufficient funds to cover the transaction fees.  
+2. Visit the [Alfajores Faucet](https://faucet.celo.org/alfajores) to claim test tokens using a wallet address. ***Remember to claim only what is needed.***
 
 ## Create a Contract on Thirdweb
 
@@ -34,8 +35,10 @@ By the end of this tutorial, you will:
 7. Click **`Deploy Now`** to finalize the process.  
 8. After deployment, well’ll be redirected to the dashboard to upload your NFTs.  
 9. Provide a **name**, upload an **image**, add a **description**, and define **traits** for the NFT.  
-10. **Lazy Mint** the NFT.  
-11. Copy the **`contract address`** from the NFT dashboard.  
+10. **Lazy Mint** the NFT.
+11. Repeat steps 9 and 10 a few times—we need at least **3 NFTs**.  
+12. Copy your **`contract address`** from the NFT dashboard.
+13. Copy the **`contract address`** from the NFT dashboard.  
 
 ## Make the NFT Mintable
 
@@ -56,37 +59,40 @@ By the end of this tutorial, you will:
 1. Clone the repository: 
  
    ```sh
-   git clone https://github.com/celo-org/one-click-quickstart
-   cd one-click-quickstart
+   git https://github.com/atejada/celo-one-click-deploy
+   cd celo-one-click-deploy
    ```
-   
+  
 2. Install dependencies:
 
 
-	```sh
-	npm install
-	```
+   ```sh
+   npm install
+   ```
 	
 3. Create a .env file with the following content:
 
 
-	```sh
-	VITE_CLIENTID=your_thirdweb_client_id
-	VITE_ADDRESS=your_nft_contract_address
-	VITE_ADRESS_TO=your_wallet_address
-	```	
+   ```sh
+   VITE_CLIENTID = THIRD_WEB_CLIENT_ID
+   VITE_ADDRESS = MINTABLE_NFT_CONTRACT
+   VITE_GALLERY_ADDRESS = NFT_GALLERY_CONTRACT
+   VITE_ADDRESS_TO = ACCOUNT_TO_SEND_CELO_TO
+   ```	
 	
 4. Run the project:
 
 
-	```sh
+   ```sh
    npm run dev
-	```
+   ```
 	
-Once the project is running, there will be two links, the first named **Send Celo** and the second named **Mint NFT**. 
+Once the project is running, there will be three links, the first named **Send Celo**, the second **NFT Gallery** and the third 
+named **Mint NFT**.
+
 The first one will be displayed by default. Click on the **Connect** button to connect the wallet. Enter an 
-address and an amount of Celo to transfer. The second link will display an NFT along with its description and by pressing
-the mint button, 0.1 Celo will be paid.
+address and an amount of Celo to transfer. The second link will display an NTF with a combo box at the top, to choose between 3 different
+NFTs. The third and last link will display an NFT along with its description and by pressing the mint button, 0.1 Celo will be paid.
 
 ## Join Build with Celo - Proof of Ship
 

--- a/docs/developer/deploy/thirdweb/one-click-deploy.md
+++ b/docs/developer/deploy/thirdweb/one-click-deploy.md
@@ -1,0 +1,103 @@
+---
+title: One-Click Deploy
+---
+
+Create and deploy Web3 apps effortlessly with Thirdweb and Celo. 
+
+---
+
+## Objectives
+
+By the end of this tutorial, you will:
+
+- Be able to transfer Celo to another address
+- Have a mintable **NFT Drop**.
+- Build an **NFT gallery**
+
+## Prerequisites
+
+* Node (v20 or higher)
+* A wallet with some test tokens (more on this later)
+
+## Fund Your Wallet  
+
+1. Ensure there are sufficient funds to cover the transaction fees.  
+2. Visit the [Alfajores Faucet](https://faucet.celo.org/alfajores) to claim test tokens using a wallet address. ***Remember to claim only what is needed.***
+
+## Create a Contract on Thirdweb
+
+1. Visit [Thirdweb](https://thirdweb.com/login) and log in or create a new account.  
+2. Navigate to **`Contracts`** and click **`Deploy Contract`**.  
+3. Since multiple smart contracts have already been audited, there's no need to write them from scratch.  
+4. Select **`NFT Drop`** and click **`Deploy`**.  
+5. Configure the token by setting its **Name** (mandatory), **Symbol**, and optionally adding an **Image** and **Description**.  
+6. In the **Deploy Options** section, choose **`Celo Alfajores`** as the Chain (if not selected by default).  
+7. Click **`Deploy Now`** to finalize the process.  
+8. After deployment, well’ll be redirected to the dashboard to upload your NFTs.  
+9. Provide a **name**, upload an **image**, add a **description**, and define **traits** for the NFT.  
+10. **Lazy Mint** the NFT.
+11. Repeat steps 9 and 10 a few times—we need at least **3 NFTs**.  
+12. Copy your **`contract address`** from the NFT dashboard.
+13. Copy the **`contract address`** from the NFT dashboard.  
+
+## Make the NFT Mintable
+
+1. On the dashboard, go to **Claim Conditions**
+2. Click on **Add Phase**.
+2. Specify the **Default Price (0.1)** and the **Limit per wallet (3)**.
+3. Click on **Save Phases**.
+
+## Get a Thirdweb Client ID  
+
+1. Open the **Thirdweb Dashboard** and click **`Add New`** in the **Projects** section.  
+2. Select **`Project`** from the dropdown menu.  
+3. Enter a **project name** and add **`localhost:5173`** under **`Allowed Domains`**. Click **`Create`**.  
+4. A **`Client ID`** and **`Secret ID`** will be generated. Copy both to a secure location—we’ll only need the **`Client ID`**.  
+
+## Clone the Thirdweb Celo NFT Repository  
+
+1. Clone the repository: 
+ 
+   ```sh
+   git https://github.com/atejada/celo-one-click-deploy
+   cd celo-one-click-deploy
+   ```
+  
+2. Install dependencies:
+
+
+   ```sh
+   npm install
+   ```
+	
+3. Create a .env file with the following content:
+
+
+   ```sh
+   VITE_CLIENTID = THIRD_WEB_CLIENT_ID
+   VITE_ADDRESS = MINTABLE_NFT_CONTRACT
+   VITE_GALLERY_ADDRESS = NFT_GALLERY_CONTRACT
+   VITE_ADDRESS_TO = ACCOUNT_TO_SEND_CELO_TO
+   ```	
+	
+4. Run the project:
+
+
+   ```sh
+   npm run dev
+   ```
+	
+Once the project is running, there will be three links, the first named **Send Celo**, the second **NFT Gallery** and the third 
+named **Mint NFT**.
+
+The first one will be displayed by default. Click on the **Connect** button to connect the wallet. Enter an 
+address and an amount of Celo to transfer. The second link will display an NTF with a combo box at the top, to choose between 3 different
+NFTs. The third and last link will display an NFT along with its description and by pressing the mint button, 0.1 Celo will be paid.
+
+## Join Build with Celo - Proof of Ship
+
+1. Create your application using an audited contract on Thirdweb.
+2. Check the Github repo [Proof-of-Ship](https://github.com/celo-org/Proof-of-Ship?tab=readme-ov-file).
+3. Sign up to join [Build with Celo - Proof of Ship](https://celo.lemonade.social/e/4JkhOXcD).
+4. You can win up to **`5k cUSD`**.
+5. Build with **`Celo`**.

--- a/docs/developer/deploy/thirdweb/overview.md
+++ b/docs/developer/deploy/thirdweb/overview.md
@@ -1,0 +1,39 @@
+# Getting Started with Thirdweb
+
+---
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Why Thirdweb?](#why-thirdweb)
+- [Thirdweb documentation](#thirdweb-docs)
+- [Resources](#resources)
+
+## Introduction {#introduction}
+
+Thirdweb streamlines blockchain development with pre-built contracts, SDKs, and a user-friendly dashboard. Deploy dApps, NFTs, and tokens effortlessly across multiple chains—fast, secure, and developer-friendly.
+
+## Why Thirdweb? {#why-thirdweb}
+
+Using Thirdweb is recommended because it eliminates the complexity of Web3 development, focusing on building rather than managing blockchain intricacies.
+
+- Pre-built Smart Contracts
+- SDKs & APIs
+- Multi-chain Support
+- Wallet & Payments
+- Dashboard Management
+
+## Thirdweb documentation {#thirdweb-docs}
+
+- Frontend
+  - [Connect](https://portal.thirdweb.com/connect)
+- Backend 
+  - [Engine](https://portal.thirdweb.com/engine)
+  - [Insight](https://portal.thirdweb.com/insight)
+  - [Nebula](https://portal.thirdweb.com/nebula)
+- Onchain
+  - [Contracts](https://portal.thirdweb.com/contracts)
+
+## Resources {#resources}
+
+- [Thirdweb main page](https://thirdweb.com/)
+- [Thirdweb Docs](https://portal.thirdweb.com/)

--- a/docs/developer/deploy/thirdweb/thirdweb.md
+++ b/docs/developer/deploy/thirdweb/thirdweb.md
@@ -19,7 +19,7 @@ To create a new smart contract using thirdweb CLI, follow these steps:
 
 2. Input your preferences for the command line prompts:
    1. Give your project a name
-   2. Choose your preferred framework: Hardhat or Foundry
+   2. Choose your preferred framework: Hardhat or Forge
    3. Name your smart contract
    4. Choose the type of base contract: Empty, [ERC20](https://portal.thirdweb.com/solidity/base-contracts/erc20base), [ERC721](https://portal.thirdweb.com/solidity/base-contracts/erc721base), or [ERC1155](https://portal.thirdweb.com/solidity/base-contracts/erc1155base)
    5. Add any desired [extensions](https://portal.thirdweb.com/solidity/extensions)
@@ -34,14 +34,25 @@ To create a new smart contract using thirdweb CLI, follow these steps:
 
    import "@thirdweb-dev/contracts/base/ERC721Base.sol";
 
-   contract Contract is ERC721Base {
-       constructor(
+   contract MyContract is ERC721Base {
+
+         constructor(
+           address _defaultAdmin,
            string memory _name,
            string memory _symbol,
            address _royaltyRecipient,
            uint128 _royaltyBps
-       ) ERC721Base(_name, _symbol, _royaltyRecipient, _royaltyBps) {}
-   }
+      )
+        ERC721Base(
+            _defaultAdmin,
+            _name,
+            _symbol,
+            _royaltyRecipient,
+            _royaltyBps
+        )
+    {}
+    
+   }    
    ```
 
    This contract inherits the functionality of ERC721Base through the following steps:
@@ -69,10 +80,12 @@ Alternatively, you can deploy a prebuilt contract for NFTs, tokens, or marketpla
 
 Deploy allows you to deploy a smart contract to any EVM compatible network without configuring RPC URLs, exposing your private keys, writing scripts, and other additional setup such as verifying your contract.
 
-1. To deploy your smart contract using deploy, navigate to the root directory of your project and execute the following command:
+1. Get a [Thirdweb Secret Key](https://thirdweb.com/team/~/~/) if you don't have one already.
+
+2. To deploy your smart contract using deploy, navigate to the root directory of your project and execute the following command:
 
    ```bash
-   npx thirdweb deploy
+   npx thirdweb deploy -k [SecretKey]
    ```
 
    Executing this command will trigger the following actions:
@@ -81,13 +94,14 @@ Deploy allows you to deploy a smart contract to any EVM compatible network witho
    - Providing the option to select which contract(s) you wish to deploy.
    - Uploading your contract source code (ABI) to IPFS.
 
-2. When it is completed, it will open a dashboard interface to finish filling out the parameters.
+3. When it is completed, it will open a dashboard interface to finish filling out the parameters.
    - `_name`: contract name
    - `_symbol`: symbol or "ticker"
    - `_royaltyRecipient`: wallet address to receive royalties from secondary sales
    - `_royaltyBps`: basis points (bps) that will be given to the royalty recipient for each secondary sale, e.g. 500 = 5%
-3. Select Celo as the network
-4. Manage additional settings on your contract’s dashboard as needed such as uploading NFTs, configuring permissions, and more.
+4. Select Celo as the network
+
+5. Manage additional settings on your contract’s dashboard as needed such as uploading NFTs, configuring permissions, and more.
 
 For additional information on Deploy, please reference [thirdweb’s documentation](https://portal.thirdweb.com/deploy).
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -594,27 +594,27 @@ const sidebars = {
       label: "Quickstart with Celo Composer",
       id: "build/quickstart",
     },
-    {
-      type: "category",
-      label: "Build with Thirdweb",
-      items: [
-        {
-          type: "doc",
-          label: "Overview",
-          id: "build/build-with-thirdweb/overview",
-        },
-        {
-          type: "doc",
-          label: "One-click Quickstart",
-          id: "build/build-with-thirdweb/one-click quickstart",
-        },
-        {
-          type: "doc",
-          label: "Celo NFT Drop Tutorial",
-          id: "build/build-with-thirdweb/celo-nft-drop-tutorial",
-        },
-      ],
-    },
+    //{
+      //type: "category",
+      //label: "Build with Thirdweb",
+      //items: [
+        //{
+          //type: "doc",
+          //label: "Overview",
+          //id: "build/build-with-thirdweb/overview",
+        //},
+        //{
+          //type: "doc",
+          //label: "One-click Quickstart",
+          //id: "build/build-with-thirdweb/one-click quickstart",
+        //},
+        //{
+          //type: "doc",
+          //label: "Celo NFT Drop Tutorial",
+          //id: "build/build-with-thirdweb/celo-nft-drop-tutorial",
+        //},
+      //],
+    //},
     {
       type: "category",
       label: "Build with AI",
@@ -969,11 +969,24 @@ const sidebars = {
           label: "Using Foundry",
           id: "developer/deploy/foundry",
         },
-        {
-          type: "doc",
-          label: "Using thirdweb",
-          id: "developer/deploy/thirdweb",
-        },
+        
+    {
+      type: "category",
+      label: "Using thirdweb",
+      items: [
+        { type: "doc", label: "Overview", id: "developer/deploy/thirdweb/overview" },
+        { type: "doc", label: "Deploy with Thirdweb CLI", id: "developer/deploy/thirdweb/thirdweb" },
+        { type: "doc", label: "One-Click Deploy", id: "developer/deploy/thirdweb/one-click-deploy" },
+      ],
+    },        
+        
+        
+        //{
+        //  type: "doc",
+        //  label: "Using thirdweb",
+        //  id: "developer/deploy/thirdweb",
+        //},
+        
         {
           type: "doc",
           label: "Using Remix",


### PR DESCRIPTION
Create a new category in the Dev Environments section called 'using Thirdweb'. Have three pages in that category (Overview, Deploy with Thirdweb CLI, One-Click Deploy)

Update 'Overview' page so that it has the information on the thirdweb portal https://portal.thirdweb.com/ Rename original 'using Thirdweb' content to 'Deploy with Thirdweb CLI' and ensure content is up to date Merge your Thirdweb tutorials into one (since the two tutorials overlap with similar content) and name it 'One-Click Deploy'"