### PR TITLE
Add redirects for contract addresses pages

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -682,3 +682,6 @@
 /blog/tutorials/devrel@celo.org /blog
 /developer/walletconnect /wallet
 /protocol/socialconnect https://github.com/celo-org/SocialConnect
+/contract-addresses /contracts/core-contracts
+/token-addresses /contracts/token-contracts
+


### PR DESCRIPTION
Add redirects for https://docs.celo.org/token-addresses and https://docs.celo.org/contract-addresses, which are linked in external sources. Links broke in https://github.com/celo-org/docs/pull/1775.