### PR TITLE
Update Alchemy links to general sdk

### DIFF
--- a/docs/network/node/overview.md
+++ b/docs/network/node/overview.md
@@ -38,13 +38,13 @@ Paid RPC endpoint hosting.
 
 ### Alchemy
 
-[Alchemy](https://docs.alchemy.com/reference/celo-api-quickstart) is a popular API provider and developer platform. Its robust, free tier offers access to enhanced features like SDKs and enhanced APIs and hosted OP Mainnet and testnet nodes.
+[Alchemy](https://docs.alchemy.com/reference/alchemy-sdk-quickstart) is a popular API provider and developer platform. Its robust, free tier offers access to enhanced features like SDKs and enhanced APIs and hosted OP Mainnet and testnet nodes.
 
 #### **Supported Networks**
 - Celo Mainnet
 - Celo Alfajores (Testnet)
 
-<PageRef url="https://docs.alchemy.com/reference/celo-api-quickstart" pageName="Alchemy" />
+<PageRef url="https://docs.alchemy.com/reference/alchemy-sdk-quickstart" pageName="Alchemy" />
 
 ### [Ankr](https://www.ankr.com/rpc/celo/)
 


### PR DESCRIPTION
- Links for celo specific section were provided, but celo specific section doesn't exist yet in the docs so the links had to be changed. 