### PR TITLE
Add natively bridged tokens

### DIFF
--- a/docs/what-is-celo/using-celo/bridged_tokens/tokens.md
+++ b/docs/what-is-celo/using-celo/bridged_tokens/tokens.md
@@ -1,7 +1,7 @@
-| Symbol | Token Name | L2 Contract Address |
-| ------ | ---------- | ------------------- |
-| AAVE | Aave Token | [0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288](https://celoscan.io/token/0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288) |
-| CRV | Curve DAO Token | [0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC](https://celoscan.io/token/0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC) |
-| UNI | Uniswap | [0xeE571697998ec64e32B57D754D700c4dda2f2a0e](https://celoscan.io/token/0xeE571697998ec64e32B57D754D700c4dda2f2a0e) |
-| WBTC | Wrapped BTC | [0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D](https://celoscan.io/token/0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D) |
-| WETH | Wrapped Ether | [0xD221812de1BD094f35587EE8E174B07B6167D9Af](https://celoscan.io/token/0xD221812de1BD094f35587EE8E174B07B6167D9Af) |
+| Symbol | Token Name | Contract Addresses |
+| ------ | ---------- | ------------------ |
+| AAVE | Aave Token | L1: [0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9](https://etherscan.io/token/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9)<br />L2: [0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288](https://celoscan.io/token/0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288) |
+| CRV | Curve DAO Token | L1: [0xD533a949740bb3306d119CC777fa900bA034cd52](https://etherscan.io/token/0xD533a949740bb3306d119CC777fa900bA034cd52)<br />L2: [0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC](https://celoscan.io/token/0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC) |
+| UNI | Uniswap | L1: [0x1f9840a85d5af5bf1d1762f925bdaddc4201f984](https://etherscan.io/token/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984)<br />L2: [0xeE571697998ec64e32B57D754D700c4dda2f2a0e](https://celoscan.io/token/0xeE571697998ec64e32B57D754D700c4dda2f2a0e) |
+| WBTC | Wrapped BTC | L1: [0x2260fac5e5542a773aa44fbcfedf7c193bc2c599](https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599)<br />L2: [0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D](https://celoscan.io/token/0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D) |
+| WETH | Wrapped Ether | L1: [0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2)<br />L2: [0xD221812de1BD094f35587EE8E174B07B6167D9Af](https://celoscan.io/token/0xD221812de1BD094f35587EE8E174B07B6167D9Af) |

--- a/docs/what-is-celo/using-celo/bridged_tokens/tokens.md
+++ b/docs/what-is-celo/using-celo/bridged_tokens/tokens.md
@@ -1,7 +1,7 @@
 | Symbol | Token Name | L2 Contract Address |
 | ------ | ---------- | ------------------- |
-| Aave Token | AAVE | [0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288](https://celoscan.io/token/0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288) |
-| Curve DAO Token | CRV | [0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC](https://celoscan.io/token/0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC) |
-| Uniswap | UNI | [0xeE571697998ec64e32B57D754D700c4dda2f2a0e](https://celoscan.io/token/0xeE571697998ec64e32B57D754D700c4dda2f2a0e) |
-| Wrapped BTC | WBTC | [0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D](https://celoscan.io/token/0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D) |
-| Wrapped Ether | WETH | [0xD221812de1BD094f35587EE8E174B07B6167D9Af](https://celoscan.io/token/0xD221812de1BD094f35587EE8E174B07B6167D9Af) |
+| AAVE | Aave Token | [0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288](https://celoscan.io/token/0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288) |
+| CRV | Curve DAO Token | [0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC](https://celoscan.io/token/0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC) |
+| UNI | Uniswap | [0xeE571697998ec64e32B57D754D700c4dda2f2a0e](https://celoscan.io/token/0xeE571697998ec64e32B57D754D700c4dda2f2a0e) |
+| WBTC | Wrapped BTC | [0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D](https://celoscan.io/token/0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D) |
+| WETH | Wrapped Ether | [0xD221812de1BD094f35587EE8E174B07B6167D9Af](https://celoscan.io/token/0xD221812de1BD094f35587EE8E174B07B6167D9Af) |

--- a/docs/what-is-celo/using-celo/bridged_tokens/tokens.md
+++ b/docs/what-is-celo/using-celo/bridged_tokens/tokens.md
@@ -1,0 +1,7 @@
+| Symbol | Token Name | L2 Contract Address |
+| ------ | ---------- | ------------------- |
+| Aave Token | AAVE | [0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288](https://celoscan.io/token/0xF6A54aff8c97f7AF3CC86dbaeE88aF6a7AaB6288) |
+| Curve DAO Token | CRV | [0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC](https://celoscan.io/token/0x75184c282e55a7393053f0b8F4F3E7BeAE067fdC) |
+| Uniswap | UNI | [0xeE571697998ec64e32B57D754D700c4dda2f2a0e](https://celoscan.io/token/0xeE571697998ec64e32B57D754D700c4dda2f2a0e) |
+| Wrapped BTC | WBTC | [0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D](https://celoscan.io/token/0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D) |
+| Wrapped Ether | WETH | [0xD221812de1BD094f35587EE8E174B07B6167D9Af](https://celoscan.io/token/0xD221812de1BD094f35587EE8E174B07B6167D9Af) |

--- a/docs/what-is-celo/using-celo/bridged_tokens/update_token_list.py
+++ b/docs/what-is-celo/using-celo/bridged_tokens/update_token_list.py
@@ -12,8 +12,8 @@ for token in tokenlist["tokens"]:
 
     output.append(
         [
-            token["name"],
             token["symbol"],
+            token["name"],
             f"[{token['address']}](https://celoscan.io/token/{token['address']})",
         ]
     )

--- a/docs/what-is-celo/using-celo/bridged_tokens/update_token_list.py
+++ b/docs/what-is-celo/using-celo/bridged_tokens/update_token_list.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import urllib.request
+import json
+
+tokenlist_url = "https://raw.githubusercontent.com/ethereum-optimism/ethereum-optimism.github.io/refs/heads/master/optimism.tokenlist.json"
+tokenlist = json.load(urllib.request.urlopen(tokenlist_url))
+
+output = []
+for token in tokenlist["tokens"]:
+    if token["chainId"] != 42220:
+        continue
+
+    output.append(
+        [
+            token["name"],
+            token["symbol"],
+            f"[{token['address']}](https://celoscan.io/token/{token['address']})",
+        ]
+    )
+
+with open("tokens.md", "w") as f:
+    f.write("| Symbol | Token Name | L2 Contract Address |\n")
+    f.write("| ------ | ---------- | ------------------- |\n")
+    for line in sorted(output, key=lambda x: x[1]):
+        f.write("| " + " | ".join(line) + " |\n")

--- a/docs/what-is-celo/using-celo/bridged_tokens/update_token_list.py
+++ b/docs/what-is-celo/using-celo/bridged_tokens/update_token_list.py
@@ -5,21 +5,31 @@ import json
 tokenlist_url = "https://raw.githubusercontent.com/ethereum-optimism/ethereum-optimism.github.io/refs/heads/master/optimism.tokenlist.json"
 tokenlist = json.load(urllib.request.urlopen(tokenlist_url))
 
+l1_address_for_token = {}
+for token in tokenlist["tokens"]:
+    if token["chainId"] != 1:
+        continue
+    l1_address_for_token[token["extensions"]["opTokenId"]] = token["address"]
+
+
 output = []
 for token in tokenlist["tokens"]:
     if token["chainId"] != 42220:
         continue
 
+    l1_address = l1_address_for_token[token["extensions"]["opTokenId"]]
     output.append(
         [
             token["symbol"],
             token["name"],
-            f"[{token['address']}](https://celoscan.io/token/{token['address']})",
+            f"L1: [{l1_address}](https://etherscan.io/token/{l1_address})"
+            "<br />"
+            f"L2: [{token['address']}](https://celoscan.io/token/{token['address']})"
         ]
     )
 
 with open("tokens.md", "w") as f:
-    f.write("| Symbol | Token Name | L2 Contract Address |\n")
-    f.write("| ------ | ---------- | ------------------- |\n")
+    f.write("| Symbol | Token Name | Contract Addresses |\n")
+    f.write("| ------ | ---------- | ------------------ |\n")
     for line in sorted(output, key=lambda x: x[1]):
         f.write("| " + " | ".join(line) + " |\n")

--- a/docs/what-is-celo/using-celo/bridges.md
+++ b/docs/what-is-celo/using-celo/bridges.md
@@ -7,13 +7,6 @@ description: How to bridge assets between Celo and other blockchain networks suc
 
 Bridging allows users to transfer assets between the Celo network and other blockchain networks such as Ethereum, Polygon, and Solana. This section provides an overview of available bridging and swapping options.
 
-:::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
-:::
-
 ---
 
 :::warning

--- a/docs/what-is-celo/using-celo/bridges.md
+++ b/docs/what-is-celo/using-celo/bridges.md
@@ -48,6 +48,13 @@ Native bridging refers to the process of transferring assets directly between La
 - [Superbridge Alfajores Testnet](https://testnets.superbridge.app/celo-alfajores)
 - [Superbridge Baklava Testnet](https://testnets.superbridge.app/celo-baklava)
 
+
+#### Natively Bridged Tokens on Mainnet
+
+import Tokens from "./bridged_tokens/tokens.md"
+
+<Tokens />
+
 ## Cross-Chain Messaging
 
 In addition to token bridges, there are also protocols that enable cross-chain messaging and interoperability:


### PR DESCRIPTION
We include the tokens from Optimism's list of bridged tokens. Since everyone can deploy tokens (with bad names or decimals) this seems to be a good source of quality information. It is also the main source of tokens displayed by Superbridge.

See https://github.com/celo-org/celo-blockchain-planning/issues/971#issuecomment-2802658428