### PR TITLE
Fix broken links

### DIFF
--- a/docs/cli/autocomplete.md
+++ b/docs/cli/autocomplete.md
@@ -34,4 +34,4 @@ EXAMPLES
   $ celocli autocomplete --refresh-cache
 ```
 
-_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v3.2.0/src/commands/autocomplete/index.ts)_
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/main/src/commands/autocomplete/index.ts)_

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -35,7 +35,7 @@ EXAMPLES
   $ celocli plugins
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.34/src/commands/plugins/index.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-autocomplete/blob/main/src/commands/autocomplete/index.ts)_
 
 ## `celocli plugins:add PLUGIN`
 


### PR DESCRIPTION
Updated outdated GitHub links in two files to point to the latest main branch versions:

In autocomplete.md:
Replaced link to v3.2.0 with link to main.

In plugins.md:
Replaced link to v5.4.34 with link to main.

These changes fix broken links and make sure the docs always point to the latest version.