### PR TITLE
fix: update plugin-help link to main branch

### DIFF
--- a/docs/cli/help.md
+++ b/docs/cli/help.md
@@ -23,4 +23,4 @@ DESCRIPTION
   Display help for celocli.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.8/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/main/src/commands/help.ts)_


### PR DESCRIPTION
Replaced static version link with a dynamic main branch link in docs/cli/help.md to ensure up-to-date reference.