### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/contracts/core-contracts.md
+++ b/docs/contracts/core-contracts.md
@@ -56,7 +56,7 @@ View Celo smart contracts [here](https://github.com/celo-org/celo-monorepo/tree/
 | UniswapFeeHandlerSeller | [0xD3aeE28548Dbb65DF03981f0dC0713BfCBd10a97](https://celoscan.io/address/0xD3aeE28548Dbb65DF03981f0dC0713BfCBd10a97) |
 | Validators              | [0xaEb865bCa93DdC8F47b8e29F40C5399cE34d0C58](https://celoscan.io/address/0xaEb865bCa93DdC8F47b8e29F40C5399cE34d0C58) |
 
-Core contracts addresses can change over time, to keep up to date with the latest, it is recomended to use the Celo CLI:
+Core contracts addresses can change over time, to keep up to date with the latest, it is recommended to use the Celo CLI:
 
 ```bash
 $ celocli network:contracts --node https://forno.celo.org
@@ -104,7 +104,7 @@ $ celocli network:contracts --node https://forno.celo.org
 | UniswapFeeHandlerSeller  | [0xc7b6E77C3702666DDa8EB5b7F30234B020788b21](https://alfajores.celoscan.io/address/0xc7b6E77C3702666DDa8EB5b7F30234B020788b21) |
 | Validators               | [0x9acF2A99914E083aD0d610672E93d14b0736BBCc](https://alfajores.celoscan.io/address/0x9acF2A99914E083aD0d610672E93d14b0736BBCc) |
 
-Core contracts addresses can change over time, to keep up to date with the latest, it is recomended to use the Celo CLI:
+Core contracts addresses can change over time, to keep up to date with the latest, it is recommended to use the Celo CLI:
 
 ```bash
 $ celocli network:contracts --node https://alfajores-forno.celo-testnet.org

--- a/docs/network/node/overview.md
+++ b/docs/network/node/overview.md
@@ -160,7 +160,7 @@ Chainstack provides global load-balanced nodes for Celo. A free developer plan i
 
 ### [All that node](https://www.allthatnode.com/celo.dsrv)
 
-All That Node supports public and private RPC nodes. They offer free private RPC nodes up to 10,000 requests/day and you can upgrade your plan as neeeded.
+All That Node supports public and private RPC nodes. They offer free private RPC nodes up to 10,000 requests/day and you can upgrade your plan as needed.
 You can also claim Alfajores funds from the faucet in the site without signing up.
 
 #### **Supported Networks**

--- a/docs/what-is-celo/about-celo-l1/validator/node-upgrade.md
+++ b/docs/what-is-celo/about-celo-l1/validator/node-upgrade.md
@@ -107,7 +107,7 @@ If reconfiguring a node to be a replica or reusing a data directory, make sure t
 
 1. Pull the latest docker image.
 2. Start a new validator node on a second host in replica mode (`--istanbul.replica` flag). It should be otherwise configured exactly the same as the existing validator.
-   - It needs to connect to the exisiting proxies and the validator signing key to connect to other validators in listen mode.
+   - It needs to connect to the existing proxies and the validator signing key to connect to other validators in listen mode.
    - If reconfiguring a node to be a replica or reusing a data directory, make sure that the node was previously configured as replica or that the `replicastate` folder is removed.
 3. Once the replica is synced and has validator enode urls for all validators, it is ready to swapped in.
    - Check validator enode urls with `istanbul.valEnodeTableInfo` in the geth console. The field `enode` should be filled in for each validator peer.


### PR DESCRIPTION


**Description:** 
This PR fixes several typos in the documentation:
- Corrects "recomended" to "recommended" in core-contracts.md
- Corrects "neeeded" to "needed" in node/overview.md
- Corrects "exisiting" to "existing" in validator/node-upgrade.md
