### PR TITLE
l2: Add Isthmus page

### DIFF
--- a/docs/cel2/notices/isthmus-upgrade.md
+++ b/docs/cel2/notices/isthmus-upgrade.md
@@ -1,0 +1,23 @@
+# Isthmus hardfork
+
+This page outlines breaking changes related to the Isthmus network upgrade for chain operators and node operators.
+
+:::info
+The Isthmus hardfork activation has not been scheduled yet. This page will be updated accordingly.
+:::
+
+## What's included in Isthmus
+
+Isthmus contains these main changes:
+
+- **Implement Prague features on the OP Stack**: This includes the EIPs that are relevant to the L2 that are being added to Ethereum with its Pectra activation. Learn more about this [here](https://gov.optimism.io/t/proposal-preview-implement-prague-features-on-the-op-stack/9703).
+
+  Notable EIP's included:
+  - [EIP-7702](https://github.com/ethereum/EIPs/blob/f27ddf2b0af7e862a967ee38ceeaa7d980786ca1/EIPS/eip-7702.md): Set code transaction
+  - [EIP-2537](https://github.com/ethereum/EIPs/blob/f27ddf2b0af7e862a967ee38ceeaa7d980786ca1/EIPS/eip-2537.md): BLS12-381 precompiles
+  - [EIP-2935](https://github.com/ethereum/EIPs/blob/f27ddf2b0af7e862a967ee38ceeaa7d980786ca1/EIPS/eip-2935.md): Block hashes contract predeploy
+  - [EIP-7623](https://github.com/ethereum/EIPs/blob/f27ddf2b0af7e862a967ee38ceeaa7d980786ca1/EIPS/eip-7623.md): Increase calldata cost
+
+- **L2 Withdrawals Root in Block Header**: This lowers the lift for chain operators by allowing them to run a full node to operate op-dispute-mon making it easier to guarantee the security of the fault proofs for the chains in the Superchain as the number of chains scales. Learn more about this [here](https://gov.optimism.io/t/proposal-preview-l2-withdrawals-root-in-block-header/9730).
+
+For more information on the Isthmus implementation details, please review [Isthmus specification](https://specs.optimism.io/protocol/isthmus/overview.html).

--- a/docs/cel2/notices/pectra-upgrade.md
+++ b/docs/cel2/notices/pectra-upgrade.md
@@ -1,14 +1,19 @@
 # Preparing for Pectra L1 hardfork
 
-:::info
-This page is not relevant for Celo Mainnet, only for the testnets Alfajores and Baklava.
-:::
+This page outlines breaking changes related to the Ethereum Pectra (Prague-Electra) L1 hard fork for node operators on the Celo networks. Please also have a look at the [Optimism Pectra update information](https://docs.optimism.io/notices/pectra-changes).
 
-This page outlines breaking changes related to the Ethereum Pectra (Prague-Electra) L1 hard fork for node operators on the Celo Alfajores & Baklava L2 Testnets. Please also have a look at the [Optimism Pectra update information](https://docs.optimism.io/notices/pectra-changes).
+## For node operators on Celo Mainnet
 
-The Pectra upgrade for Holesky L1 was activated on slot: 3710976 (Mon, Feb 24 at 21:55:12 UTC).
+The releases for the Celo L2 migration already include the necessary changes for L1 Pectra compatibility.
+
+The following versions are necessary for every node operator, we recommend to use the latest versions available.
+
+* `op-geth`: [celo-v2.0.0](https://github.com/celo-org/op-geth/releases/tag/celo-v2.0.0)
+* `op-node`: [celo-v2.0.0](https://github.com/celo-org/optimism/releases/tag/celo-v2.0.0)
 
 ## Testnet issues
+
+The Pectra upgrade for Holesky L1 was activated on slot: 3710976 (Mon, Feb 24 at 21:55:12 UTC).
 
 Holesky, the L1 chain that both Alfajores and Baklava testnets use, suffered from a chain split shortly after the Pectra hardfork. The network now produces blocks again, but is not yet finalizing again. For more information see the [Post-Mortem](https://github.com/ethereum/pm/blob/master/Pectra/holesky-postmortem.md).
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -1208,6 +1208,11 @@ const celoL2Sidebar = [
     collapsed: false,
     items: [
       {
+        type: "doc",
+        label: "Isthmus Upgrade",
+        id: "cel2/notices/isthmus-upgrade",
+      },
+      {
         type: "category",
         label: "Celo L2 Migration",
         link: {
@@ -1225,7 +1230,7 @@ const celoL2Sidebar = [
       },
       {
         type: "doc",
-        label: "Pectra Upgrade",
+        label: "L1 Pectra Upgrade",
         id: "cel2/notices/pectra-upgrade",
       },
     ],


### PR DESCRIPTION
Add page with Isthmus information.


Side questions: Do we want to keep the information bar and the notice for the migration, or should we remove those?

Resolves https://github.com/celo-org/celo-blockchain-planning/issues/1012