### PR TITLE
Update plugin-commands link to main branch

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -33,4 +33,4 @@ DESCRIPTION
   List all celocli commands.
 ```
 
-_See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/v4.1.21/src/commands/commands.ts)_
+_See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/main/src/commands/commands.ts)_


### PR DESCRIPTION
Updated GitHub link in commands.md to point to the main branch instead of a specific version for better maintainability.