### PR TITLE
add links to MiniPay iOS app

### DIFF
--- a/docs/build/build-on-minipay/overview.mdx
+++ b/docs/build/build-on-minipay/overview.mdx
@@ -7,7 +7,7 @@ description: A guide  for building on MiniPay and Celo.
 
 ---
 
-[MiniPay](https://www.opera.com/products/minipay) is a stablecoin wallet with a built-in Mini App discovery page, integrated directly within the popular Opera Mini Android browser and also available as a standalone application on Android (iOS soon).
+[MiniPay](https://www.opera.com/products/minipay) is a stablecoin wallet with a built-in Mini App discovery page, integrated directly within the popular Opera Mini Android browser and also available as a standalone application on Android and iOS.
 
 Since launching, MiniPay is the fastest growing non-custodial wallet in the Global South—accounting for 25% of new USDT addresses in Q4 2024 and over 5M+ activations.
 

--- a/docs/build/build-on-minipay/quickstart.md
+++ b/docs/build/build-on-minipay/quickstart.md
@@ -24,11 +24,12 @@ MiniPay is only available on Celo and Celo Alfajores Testnet. Other blockchain n
 
 #### How to Access MiniPay:
 - [**Opera Mini Browser**](https://www.opera.com/pl/products/minipay) (Android) 
-- [**Standalone App**](https://play.google.com/store/apps/details?id=com.opera.minipay) (Android, iOS coming soon)
+- [**Standalone App Android**](https://play.google.com/store/apps/details?id=com.opera.minipay)
+- [**Standalone App iOS**](https://apps.apple.com/de/app/minipay-easy-global-wallet/id6504087257?l=en-GB)
 
 #### Set Up MiniPay:
 
-- **Install the MiniPay Standalone App:** [Download here.](https://play.google.com/store/apps/details?id=com.opera.minipay)
+- **Install the MiniPay Standalone App:** Download for [Android](https://play.google.com/store/apps/details?id=com.opera.minipay) and [iOS](https://apps.apple.com/de/app/minipay-easy-global-wallet/id6504087257?l=en-GB)
 - **Create an Account:** Sign up using your Google account and phone number.
 
 ## 2. Build Your MiniPay Mini App
@@ -53,7 +54,7 @@ Request testnet tokens from the Celo [faucet](https://faucet.celo.org/) to test 
 ## 4. Test your Mini App inside MiniPay
 
 :::warning
-You cannot test MiniPay using the Android Studio Emulator. Use an Android mobile device.
+You cannot test MiniPay using the Android Studio Emulator. Use an Android or iOS mobile device.
 :::
 
 ### Enable Developer Mode:

--- a/docs/wallet/index.md
+++ b/docs/wallet/index.md
@@ -43,7 +43,7 @@ Valora is a non-custodial multichain mobile wallet focused on helping users save
 MiniPay is a non-custodial lightweight mobile wallet that allows users to send and receive stablecoins with transaction below 1 cent. It was first launched within the Opera Mini browser to assist people in sending and receiving stablecoins using mobile numbers.
 
 - Homepage: [opera.com/products/minipay](https://www.opera.com/products/minipay)
-- Platforms: [Android](https://play.google.com/store/apps/details?id=com.opera.minipay), iOS (testflight only), inside [Opera Mini](https://play.google.com/store/apps/details?id=com.opera.mini.native) in Ghana, Nigeria, Kenya, South Africa, and Uganda
+- Platforms: [Android](https://play.google.com/store/apps/details?id=com.opera.minipay), [iOS](https://apps.apple.com/de/app/minipay-easy-global-wallet/id6504087257?l=en-GB), inside [Opera Mini](https://play.google.com/store/apps/details?id=com.opera.mini.native) in Ghana, Nigeria, Kenya, South Africa, and Uganda
 - Maintainers: Opera
 - Ledger support: No
 - Supported tokens: cUSD, USDT, and USDC


### PR DESCRIPTION
MiniPay is out on iOS now, so updates to all links to where to download MiniPay was required. 