### PR TITLE
Fix Typos in Validator Documentation

### DIFF
--- a/docs/what-is-celo/about-celo-l1/validator/troubleshooting-faq.md
+++ b/docs/what-is-celo/about-celo-l1/validator/troubleshooting-faq.md
@@ -5,7 +5,7 @@ description: Answers to frequently asked questions while troubleshooting issues 
 
 # Validator FAQ
 
-Answers to frequently asked questions while troubleshooting isses as a Validator.
+Answers to frequently asked questions while troubleshooting issues as a Validator.
 
 :::warning
 As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!

--- a/docs/what-is-celo/about-celo-l1/validator/validator-explorer.md
+++ b/docs/what-is-celo/about-celo-l1/validator/validator-explorer.md
@@ -94,7 +94,7 @@ celocli account:create-metadata ./validator_metadata.json --from $CELO_VALIDATOR
 celocli account:claim-account ./validator_metadata.json --address $CELO_VALIDATOR_GROUP_RG_ADDRESS --from $CELO_VALIDATOR_SIGNER_ADDRESS
 ```
 
-And then host both metadata files somewhere reachable via HTTP. You can use a service like gist.github.com. Create two gists, each with the contents of the respective files and then click on the Raw buttton to receive the permalinks to the machine-readable file. If you had already registered a metadata URL for your `validator` you just need to update that registerd gist, so you can skip the `validator` metadata registration below.
+And then host both metadata files somewhere reachable via HTTP. You can use a service like gist.github.com. Create two gists, each with the contents of the respective files and then click on the Raw button to receive the permalinks to the machine-readable file. If you had already registered a metadata URL for your `validator` you just need to update that registerd gist, so you can skip the `validator` metadata registration below.
 
 Now we can register these URLs on each account:
 


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the Celo validator documentation. Specifically, it fixes the word "issues" in the troubleshooting FAQ and the word "button" in the validator explorer guide. These changes improve the clarity and professionalism of the documentation. No functional or structural changes were made.