### PR TITLE
Add MCP guide button on docs landing page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -90,6 +90,30 @@ export default function HomePage(): JSX.Element {
                 />
               </svg>
             </Link>
+            <p className="mt-6 max-w-md">
+              Try Celo's new MCP Servers to iterate quickly using AI coding
+              tools
+            </p>
+            <Link
+              href={"/build/mcp/celo-mcp"}
+              className="flex space-x-2 items-center mt-2"
+            >
+              <span className="text-lg font-semibold">Celo MCP Guide</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-5 h-5"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25"
+                />
+              </svg>
+            </Link>
           </div>
           <div className="flex justify-center md:w-1/2 w-full h-full ">
             <HeroImage />
@@ -297,7 +321,6 @@ export default function HomePage(): JSX.Element {
               </svg>
             </a>
 
-
             <a
               href="/build/build-with-defi"
               target="_blank"
@@ -388,10 +411,8 @@ export default function HomePage(): JSX.Element {
                   strokeLinejoin="round"
                   d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25"
                 />
-
               </svg>
             </a>
-
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add call to action promoting the new MCP guides

## Testing
- `npx prettier -w src/pages/index.tsx`
- `npm run build` *(fails: docusaurus not found)*

------
https://chatgpt.com/codex/tasks/task_b_685070d11078832c8a6d291adf272683