### PR TITLE
Celo L1 consensus refactor

### DIFF
--- a/docs/what-is-celo/about-celo-l1/protocol/consensus/index.md
+++ b/docs/what-is-celo/about-celo-l1/protocol/consensus/index.md
@@ -8,10 +8,7 @@ description: Overview of Celo's consensus protocol and network validators.
 Overview of Celo's consensus protocol and network validators.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/protocol/consensus/locating-nodes.md
+++ b/docs/what-is-celo/about-celo-l1/protocol/consensus/locating-nodes.md
@@ -8,10 +8,7 @@ description: How Celo nodes join the network, establish a connection, and commun
 How Celo nodes join the network, establish a connection, and communiate their IP address.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/protocol/consensus/validator-set-differences.md
+++ b/docs/what-is-celo/about-celo-l1/protocol/consensus/validator-set-differences.md
@@ -8,10 +8,7 @@ description: How validator sets are elected and managed with the Celo protocol.
 How validator sets are elected and managed with the Celo protocol.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---


### PR DESCRIPTION
Introduce a disclaimer in the documentation to clarify that the content pertains to the historical Celo Layer 1 blockchain and does not reflect the current state of the network after its transition to Ethereum Layer 2.