### PR TITLE
Celo L1 validator refactor

### DIFF
--- a/docs/what-is-celo/about-celo-l1/validator/celo-foundation-voting-policy.md
+++ b/docs/what-is-celo/about-celo-l1/validator/celo-foundation-voting-policy.md
@@ -6,10 +6,7 @@ description: How the Celo Foundation anticipates allocating its votes to validat
 How the Celo Foundation anticipates allocating its votes to validator groups, with special attention to the first allocated groups at the Celo Mainnet release and the months thereafter.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/devops-best-practices.md
+++ b/docs/what-is-celo/about-celo-l1/validator/devops-best-practices.md
@@ -8,10 +8,7 @@ description: Best practices for running cloud infrastructure for Celo nodes and 
 Best practices for running cloud infrastructure for Celo nodes and services.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/index.md
+++ b/docs/what-is-celo/about-celo-l1/validator/index.md
@@ -12,10 +12,7 @@ import TabItem from '@theme/TabItem';
 Secure the Celo network by participating in the consensus of the Celo protocol.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/key-management/detailed.md
+++ b/docs/what-is-celo/about-celo-l1/validator/key-management/detailed.md
@@ -8,10 +8,7 @@ description: Detailed description of the various account roles found in the Celo
 Detailed descriptions of the various account roles as found in the Celo protocol with examples of how to designate an account as playing a particular role.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/key-management/key-rotation.md
+++ b/docs/what-is-celo/about-celo-l1/validator/key-management/key-rotation.md
@@ -8,10 +8,7 @@ description: How to manage signer key rotations as a Celo Validator.
 How to manage signer key rotations as a Celo Validator.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/key-management/summary.md
+++ b/docs/what-is-celo/about-celo-l1/validator/key-management/summary.md
@@ -1,17 +1,14 @@
 ---
-title: Celo Key Management Summary
+title: Overview
 description: Introduction to the philosophy and account roles related to key management on Celo.
 ---
 
-# Summary
+# Overview
 
 Introduction to the philosophy and account roles related to key management on Celo.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/monitoring.md
+++ b/docs/what-is-celo/about-celo-l1/validator/monitoring.md
@@ -8,10 +8,7 @@ description: Commands, metrics, APIs, and services for monitoring Validators and
 Commands, metrics, APIs, and services for monitoring Validators and Proxies.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/node-upgrade.md
+++ b/docs/what-is-celo/about-celo-l1/validator/node-upgrade.md
@@ -8,10 +8,7 @@ description: How to upgrade to the newest available version of a Celo node.
 How to upgrade to the newest available version of a Celo node.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/proxy.md
+++ b/docs/what-is-celo/about-celo-l1/validator/proxy.md
@@ -8,10 +8,7 @@ description: How to ensure Validator uptime by running proxy nodes.
 How to ensure Validator uptime by running proxy nodes.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/run/mainnet.md
+++ b/docs/what-is-celo/about-celo-l1/validator/run/mainnet.md
@@ -8,21 +8,10 @@ description: How to get a Validator node running on the Celo Mainnet.
 How to get a Validator node running on the Celo Mainnet.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---
-
-:::info
-
-If you would like to keep up-to-date with all the news happening in the Celo community, including validation, node operation and governance, please sign up to our [Celo Signal mailing list here](https://share.hsforms.com/1Qrhush1vSA2WIamd_yL4ow53n4j).
-
-You can add the [Celo Signal public calendar](https://calendar.google.com/calendar/u/0/embed?src=c_9su6ich1uhmetr4ob3sij6kaqs@group.calendar.google.com) as well which has relevant dates.
-
-:::
 
 ## What is a Validator?
 

--- a/docs/what-is-celo/about-celo-l1/validator/security.md
+++ b/docs/what-is-celo/about-celo-l1/validator/security.md
@@ -8,10 +8,7 @@ description: Recommendations for running secure Celo nodes and services.
 Recommendations for running secure Celo nodes and services.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/troubleshooting-faq.md
+++ b/docs/what-is-celo/about-celo-l1/validator/troubleshooting-faq.md
@@ -8,10 +8,7 @@ description: Answers to frequently asked questions while troubleshooting issues 
 Answers to frequently asked questions while troubleshooting issues as a Validator.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/validator-explorer.md
+++ b/docs/what-is-celo/about-celo-l1/validator/validator-explorer.md
@@ -8,10 +8,7 @@ description: How to use the Validator Explorer to view Validator performance.
 How to use the Validator Explorer to view Validator performance.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/about-celo-l1/validator/voting.md
+++ b/docs/what-is-celo/about-celo-l1/validator/voting.md
@@ -8,10 +8,7 @@ description: Overview of Validator elections for Validator groups including tech
 Resources for Validator Groups elections including technical details, policies, and Validator explorers.
 
 :::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
+This page describes the historical Celo Layer 1 blockchain. It is useful for understanding Celo’s history, but does not reflect the current state of the network. As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo has transitioned to an Ethereum Layer 2.
 :::
 
 ---

--- a/docs/what-is-celo/joining-celo/celo-signal.md
+++ b/docs/what-is-celo/joining-celo/celo-signal.md
@@ -13,16 +13,15 @@ How to join the mailing list for everything involving the Celo core community an
 
 **If you are a:**
 
-- Validator
 - Node Operator
-- Dapp Running Its Own Node
+- dApp Running Its Own Node
 - Exchange or Custodian
 - Owner who is Staking + Participating in Governance
 - Core Developer or Contributor
 
 Then Celo Signal Mailing List is a great way to keep up with everything happening in Celo's core community.
 
-**Updates include information on following events:**
+**Updates include information on the following events:**
 
 - Celo All-Core Dev Call (where Celo Platform enhancements and proposals are discussed in the community)
 - Celo Governance Call (where governance proposals are discussed prior to submission on-chain)
@@ -33,14 +32,10 @@ Then Celo Signal Mailing List is a great way to keep up with everything happenin
 - Core Community Happy Hour
 - Ongoing or Upcoming Hackathons & Updates
 
-:::note
-
+:::note Join the Mailing List
 If you would like to keep up-to-date with all the news happening in the Celo community, including validation, node operation and governance, please sign up to our [Celo Signal mailing list here](https://share.hsforms.com/1Qrhush1vSA2WIamd_yL4ow53n4j).
-
 :::
 
-:::tip
-
+:::tip Add the Celo Signal Calendar
 You can add the [Celo Signal public calendar](https://calendar.google.com/calendar/u/0/embed?src=c_9su6ich1uhmetr4ob3sij6kaqs@group.calendar.google.com) as well which has relevant dates.
-
 :::

--- a/sidebars.js
+++ b/sidebars.js
@@ -251,6 +251,11 @@ const whatIsCeloSidebar = [
         ],
       },
       {
+        type: "doc",
+        label: "Celo Signal",
+        id: "what-is-celo/joining-celo/celo-signal",
+      },
+      {
         type: "link",
         label: "Code of Conduct",
         href: "https://github.com/celo-org/website/blob/master/src/content/code-of-conduct.md",
@@ -594,11 +599,6 @@ const whatIsCeloSidebar = [
             type: "doc",
             label: "Voting Policy",
             id: "what-is-celo/about-celo-l1/validator/celo-foundation-voting-policy",
-          },
-          {
-            type: "doc",
-            label: "Celo Signal",
-            id: "what-is-celo/about-celo-l1/validator/celo-signal",
           },
           {
             type: "doc",

--- a/static/_redirects
+++ b/static/_redirects
@@ -733,7 +733,7 @@
 /v/master/getting-started/baklava-testnet /network
 /validator-guide/attestation-service /validator/attestation
 /validator-guide/celo-foundation-voting-policy /validator/celo-foundation-voting-policy
-/validator-guide/celo-signal /validator/celo-signal
+/validator-guide/celo-signal /what-is-celo/joining-celo/celo-signal
 /validator-guide/devops-best-practices /validator/devops-best-practices
 /validator-guide/key-management/detailed /validator/key-management/detailed
 /validator-guide/key-management/key-rotation /validator/key-management/key-rotation
@@ -747,7 +747,7 @@
 /validator-guide/validator-explorer /validator/validator-explorer
 /validator/attestation /what-is-celo/about-celo-l1/validator/attestation
 /validator/celo-foundation-voting-policy /what-is-celo/about-celo-l1/validator/celo-foundation-voting-policy
-/validator/celo-signal /what-is-celo/about-celo-l1/validator/celo-signal
+/validator/celo-signal /what-is-celo/joining-celo/celo-signal
 /validator/devops-best-practices /what-is-celo/about-celo-l1/validator/devops-best-practices
 /validator/key-management/detailed /what-is-celo/about-celo-l1/validator/key-management/detailed
 /validator/key-management/key-rotation /what-is-celo/about-celo-l1/validator/key-management/key-rotation
@@ -762,6 +762,7 @@
 /validator/run/mainnet /what-is-celo/about-celo-l1/validator/run/mainnet
 /validator/security /what-is-celo/about-celo-l1/validator/security
 /validator/troubleshooting-faq /what-is-celo/about-celo-l1/validator/troubleshooting-faq
+/what-is-celo/about-celo-l1/validator/celo-signal /what-is-celo/joining-celo/celo-signal
 /what-is-celo/joining-celo/contributors/code-of-conduct https://celo.org/code-of-conduct
 /what-is-celo/using-celo/glossary /glossary
 /what-is-celo/using-celo/protocol/governance /what-is-celo/using-celo/protocol/governance/overview


### PR DESCRIPTION
Update warnings and notices on validator documentation.
Move Celo Signal page out of L1.