### PR TITLE
Celo L2 Epoch Rewards refactor

### DIFF
--- a/docs/what-is-celo/using-celo/protocol/epoch-rewards/carbon-offsetting-fund.md
+++ b/docs/what-is-celo/using-celo/protocol/epoch-rewards/carbon-offsetting-fund.md
@@ -7,33 +7,17 @@ description: Introduction to the Carbon Offsetting fund, its purpose, and govern
 
 Introduction to the Carbon Offsetting fund, its purpose, and governance process.
 
-:::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
-:::
-
 ---
 
 :::info
-This status is based on the proposal ["The Great Celo Halvening – Proposed Tokenomics in the Era of Celo L2"](https://forum.celo.org/t/the-great-celo-halvening-proposed-tokenomics-in-the-era-of-celo-l2/9701).
+Check out the ["The Great Celo Halvening – Proposed Tokenomics in the Era of Celo L2"](https://forum.celo.org/t/the-great-celo-halvening-proposed-tokenomics-in-the-era-of-celo-l2/9701).
 :::
 
 ## What is the Carbon Offsetting Fund?
 
-The Carbon Offsetting Fund provides for making the infrastructure of the Celo platform carbon-negative, by making a transfer every epoch to an organization that commits to using those assets off-chain for carbon offsetting projects.
+The Carbon Offsetting Fund represents Celo's commitment to environmental sustainability by making the platform's infrastructure **carbon-negative**. The fund automatically transfers resources every epoch to partner organizations that use these assets for verified carbon offsetting projects.
 
-## Governance
+## How the Carbon Offsetting Fund Receives Assets
 
-Through the [on-chain governance process](/what-is-celo/using-celo/protocol/governance/overview/), CELO holders can set the fraction of the total desired epoch rewards, initially planned to be 0.1%, that is received by the carbon offsetting fund, and the address of a carbon offsetting partner to which to direct these transfers. The on-target amount is adjusted by the epoch [rewards multiplier](/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards), as with all epoch rewards.
-
-### Transaction Fee Allocation
-
-- **10% of transaction fees** support the carbon offset fund, supporting Celo’s environmental commitment.
-- **90% of transaction fees** are being directed toward funding key network operations, including:
-  - Data Availability
-  - Layer 1 Fees
-  - Sequencer and Batcher Operations
-  - Revenue sharing with the OP-Stack
-
+- **Epoch rewards**: the Carbon Offsetting Fund receives 0.1% of epoch rewards, adjustable via governance and distributed automatically at each epoch.
+- **Transaction fees**: the Carbon Offsetting Fund receives 10% of transaction fees, adjustable via governance.

--- a/docs/what-is-celo/using-celo/protocol/epoch-rewards/community-fund.md
+++ b/docs/what-is-celo/using-celo/protocol/epoch-rewards/community-fund.md
@@ -7,13 +7,6 @@ description: Introduction to the community fund, its assets, and its relationshi
 
 Introduction to the community fund, its assets, and its relationship to the on-chain reserve.
 
-:::warning
-As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
-Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
-
-For the most up-to-date information, refer to our [Celo L2 documentation](https://docs.celo.org/cel2).
-:::
-
 ---
 
 :::info
@@ -22,12 +15,20 @@ Check out the [State of Celo Community Treasury | Q1 2025](https://forum.celo.or
 
 ## What is the Community Fund?
 
-The Community Fund provides for the general upkeep of the Celo platform. CELO holders decide how to allocate these funds through governance proposals in the [governance forum](https://forum.celo.org/). Funds might be used to pay bounties for bugs or vulnerabilities, security audits, or grants for protocol development.
+The Community Fund supports the ongoing development and maintenance of the Celo platform. CELO holders collectively decide how to allocate these funds through governance proposals submitted to the [governance forum](https://forum.celo.org/c/governance/12).
 
-## Community Fund Assets
+## How the Community Fund Receives Assets
 
-The Community Fund receives assets from two sources:
+The Community Fund is funded through two primary mechanisms:
 
-- The Community Fund obtains a desired epoch reward defined as a fraction of the total desired epoch rewards \(governable, initially planned to be $$25\%$$\). This amount is subject to adjustment up or down in the event of under- or over-spending against the epoch rewards target schedule.
+- **Epoch rewards**: the Community Fund receives 1% of epoch rewards, adjustable via governance and distributed automatically at each epoch.
 
-- The Community Fund is the default destination for slashed assets.
+- **Slashed assets**: the Community Fund is the default destination for slashed assets.
+
+In April 2023, [CGP-79](https://mondo.celo.org/governance/cgp-79) was passed, enabling the Mento Reserve to return 120M CELO (originally allocated at genesis) to the Celo Community Fund.
+
+## On-chain and Analytics
+
+All Community Fund activities are transparent and verifiable on-chain: [0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972](https://celoscan.io/address/0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972).
+
+For deeper analysis of Community Fund activities, use the [Dune Analytics dashboard](https://dune.com/superchain_eco/celo-community-treasury).

--- a/docs/what-is-celo/using-celo/protocol/epoch-rewards/index.md
+++ b/docs/what-is-celo/using-celo/protocol/epoch-rewards/index.md
@@ -1,56 +1,95 @@
 ---
 title: Celo Epoch Rewards Overview
-description: Introduction to Celo epoch rewards on Celo as an L2.
+description: Introduction to Celo epoch rewards on Celo.
 ---
 
 # L2 Epoch Rewards
 
-Introduction to Celo epoch rewards on Celo as an L2.
+Learn how Celo distributes rewards to network participants.
 
-**Epoch Rewards** are similar to the familiar notion of block rewards in other blockchains, minting and distributing new units of CELO as blocks are produced, to create several kinds of incentives.
+---
 
-In the L2 ["epoch blocks”](/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards) no longer exist. There are no transactions triggered by the blockchain itself. Precompiles that were used to query epoch state are also no longer available.
+## What are Epoch Rewards?
 
-The concept for epochs still remains, but they are determined to be at least as long as "epoch duration” (targeted to be set as one day on mainnet), but there's no guaranteed limit of the maximal duration. The size of an epoch can no longer be deterministically calculated based on block numbers alone.
+**Epoch Rewards** function similarly to block rewards in other blockchains. They distribute new CELO tokens as epochs progress, creating incentives for various network participants.
 
-The logic for processing epochs is now fully implemented in Solidity in the [EpochManager contract](/contracts/core-contracts) introduced in [Contract Release 12](https://github.com/celo-org/celo-monorepo/tree/core-contracts.v12).
+## How Epoch Rewards Work
 
-Epochs are now processed using multiple calls, as the gas consumption of the process involved uses is relatively high.
+Rewards are distributed at the end of each epoch (roughly every 24 hours) to:
 
-Celo is no longer minted when processing the epoch, it is now transferred from the `CeloUnreleasedTreasury`. The contract `CeloUnreleasedTreasury` was allocated the full amount of unminted Celo at the time of the transition to L2.
+- **Community RPC providers** - Node operators serving the network
+- **Locked CELO holders** - Users who vote for groups that elected community RPC providers
+- **Community Fund** - Supporting protocol infrastructure grants
+- **Carbon Offsetting Fund** - Environmental sustainability initiatives
 
-When "epoch duration" has elapsed since the current epoch started, the function `startNextEpochProcess` can be called. This function:
+## Token Economics
 
-1. Is permissionless, every EOA or contract can call it given that certain conditions are met:
-    1. Enough time has elapsed after the beginning of the epoch.
-    2. The epoch is not currently processing.
-2. Updates target voting yield
-3. Calculates epoch rewards (`EpochRewards.calculateTargetEpochRewards()`)
+A total of **400 million CELO** will be released through epoch rewards over time. CELO serves multiple roles:
 
-4. Allocates validator rewards:
+- Utility and governance token for the Celo network
+- Reserve collateral backing Celo stablecoins
+- Fixed supply asset with long-term deflationary characteristics (similar to Ethereum)
 
-    1. mints CELO and exchanges it to cUSD
-    2. Sets an internal mapping with the allocation for each validator. Validators can later claim it calling `sendValidatorPayment`
-5. Starts a block that prevents certain actions to be performed, notable lock Celo, unlock Celo and change validator locks.
+:::info **Migration from L1 to L2**
+For details on how epoch rewards worked when Celo was a Layer 1 blockchain, see [the historical epoch rewards section](/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards).
 
-6. Emits events:
+For technical changes since the L1 to L2 migration, refer to the [official specs](https://specs.celo.org/smart_contract_updates_from_l1.html#epochs-and-rewards).
+:::
 
-    1. EpochRewards: `TargetVotingYieldUpdated(uint256 fraction)`
-    2. CeloUnreleasedTreasury: `Released(address indexed to, uint256 amount)`
-    3. cUSD: `Transfer(address indexed from, address indexed to, uint256 value)`
-    4. EpochManager: `EpochProcessingStarted(uint256 indexed epochNumber)`
+## Epoch Duration and Processing
 
-After `startNextEpochProcess` is called, the epoch can be fully finished by calling `finishNextEpochProcess` . This function:
+An epoch is a time period lasting at least one day, with no guaranteed maximum duration.
+The epoch logic is implemented in Solidity via the [EpochManager contract](/contracts/core-contracts), introduced in [Contract Release 12](https://github.com/celo-org/celo-monorepo/tree/core-contracts.v12).
 
-1. Is permissionless, every EOA or contract can call it given that certain conditions are met:
-    1. startNextEpochProcess has been called before.
-2. Distributes rewards to voters (Celo)
-3. Elects validators (the result is stored as an array of accounts of the elected validators, signers are also stored for backwards compatibility purposes)
-4. Unblocks all actions blocked in `startNextEpochProcess` .
-5. Updates the Epoch state.
+Since epoch processing requires significant gas consumption, it's handled through multiple function calls rather than a single transaction.
 
-6. Emits events:
+## Reward Distribution Process
 
-    1. Election: `EpochRewardsDistributedToVoters(address indexed group, uint256 value)`
-    2. CeloUnreleasedTreasury: `Released(address indexed to, uint256 amount)`
-    3. EpochManager: `EpochProcessingEnded(uint256 indexed epochNumber)`
+CELO tokens are transferred from the `CeloUnreleasedTreasury` contract, which was allocated the full amount of unminted CELO during the L2 transition.
+
+:::info **Terminology**
+The term "validator" is used in the code and corresponding explanation due to historical reasons, but refers to the community RPC providers.
+:::
+
+### Phase 1: Starting Epoch Processing
+
+When the epoch duration has elapsed, anyone can call `startNextEpochProcess()` to begin reward distribution.
+
+**Requirements:**
+
+- Sufficient time has passed since the current epoch began.
+- No epoch is currently being processed.
+
+**Actions performed:**
+
+1. **Updates target voting yield** - Adjusts reward rates
+2. **Calculates epoch rewards** - Determines total rewards via `EpochRewards.calculateTargetEpochRewards()`
+3. **Allocates validator rewards:**
+   - Mints CELO and exchanges it for cUSD
+   - Creates internal mapping for validator allocations
+   - Validators later claim rewards by calling `sendValidatorPayment`
+4. **Activates protection mode** - Temporarily blocks certain actions (locking/unlocking CELO, changing validator locks)
+5. **Emits events:**
+   - EpochRewards: `TargetVotingYieldUpdated(uint256 fraction)`
+   - CeloUnreleasedTreasury: `Released(address indexed to, uint256 amount)`
+   - cUSD: `Transfer(address indexed from, address indexed to, uint256 value)`
+   - EpochManager: `EpochProcessingStarted(uint256 indexed epochNumber)`
+
+### Phase 2: Completing Epoch Processing
+
+After the initial phase, anyone can call `finishNextEpochProcess()` to complete the epoch.
+
+**Requirements:**
+
+- `startNextEpochProcess` must have been called previously.
+
+**Actions performed:**
+
+1. **Distributes voter rewards** - Sends CELO to eligible voters
+2. **Conducts validator elections** - Stores elected validator accounts and signers
+3. **Removes protection mode** - Re-enables previously blocked actions
+4. **Updates epoch state** - Advances to the next epoch
+5. **Emits events:**
+   - Election: `EpochRewardsDistributedToVoters(address indexed group, uint256 value)`
+   - CeloUnreleasedTreasury: `Released(address indexed to, uint256 amount)`
+   - EpochManager: `EpochProcessingEnded(uint256 indexed epochNumber)`


### PR DESCRIPTION
Enhance clarity and remove outdated warnings in the documentation for the Carbon Offsetting Fund and Community Fund, improving understanding of fund mechanisms and governance processes.

celo-org/celo-blockchain-planning#1173