### PR TITLE
Update EigenDA proxy links

### DIFF
--- a/docs/cel2/notices/eigenda-v2-upgrade.md
+++ b/docs/cel2/notices/eigenda-v2-upgrade.md
@@ -26,4 +26,4 @@ Support for decentralized dispersal is unlocked by eliminating DDoS attack surfa
 
 ## For Node Operators
 
-Node operators need to upgrade the [EigenDA proxy](https://github.com/Layr-Labs/eigenda-proxy) to version [v1.8.2](https://github.com/Layr-Labs/eigenda-proxy/releases/tag/v1.8.2) before the activation date. The version is backwards compatible with EigenDA v1 and can be updated beforehand.
+Node operators need to upgrade the [EigenDA proxy](https://github.com/Layr-Labs/eigenda/tree/master/api/proxy) to version [v1.8.2](https://github.com/Layr-Labs/eigenda/pkgs/container/eigenda-proxy/437919973?tag=v1.8.2) before the activation date. The version is backwards compatible with EigenDA v1 and can be updated beforehand.

--- a/docs/cel2/notices/isthmus-upgrade.md
+++ b/docs/cel2/notices/isthmus-upgrade.md
@@ -54,7 +54,7 @@ The release contains the activation timestamps for Celo Mainnet, Baklava and Alf
 
 The Isthmus hardfork also prepares the Celo networks for the EigenDA v2 update.
 
-This means that operators need to make sure to upgrade the [EigenDA proxy](https://github.com/Layr-Labs/eigenda-proxy) to version [v1.8.2](https://github.com/Layr-Labs/eigenda-proxy/releases/tag/v1.8.2).
+This means that operators need to make sure to upgrade the [EigenDA proxy](https://github.com/Layr-Labs/eigenda/tree/master/api/proxy) to version [v1.8.2](https://github.com/Layr-Labs/eigenda/pkgs/container/eigenda-proxy/437919973?tag=v1.8.2).
 
 ### Verify Your Configuration
 


### PR DESCRIPTION
https://github.com/Layr-Labs/eigenda-proxy is deprecated and archived, link to https://github.com/Layr-Labs/eigenda/tree/master/api/proxy and https://github.com/Layr-Labs/eigenda/pkgs/container/eigenda-proxy instead.