### PR TITLE
Rename Consensus section to Security Council

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8,13 +8,7 @@
     "dark": "#000000"
   },
   "contextual": {
-    "options": [
-      "copy",
-      "view",
-      "chatgpt",
-      "claude",
-      "cursor"
-    ]
+    "options": ["copy", "view", "chatgpt", "claude", "cursor"]
   },
   "background": {
     "color": {
@@ -41,9 +35,7 @@
         "groups": [
           {
             "group": "Introduction",
-            "pages": [
-              "home/celo"
-            ]
+            "pages": ["home/celo"]
           },
           {
             "group": "Overview",
@@ -67,7 +59,7 @@
             "group": "Protocol",
             "pages": [
               "home/protocol/index",
-              "home/protocol/consensus",
+              "home/protocol/security-council",
               "home/protocol/celo-token",
               "home/protocol/escrow"
             ]
@@ -201,9 +193,7 @@
           },
           {
             "group": "Testnets",
-            "pages": [
-              "tooling/testnets/celo-sepolia/index"
-            ]
+            "pages": ["tooling/testnets/celo-sepolia/index"]
           },
           {
             "group": "Nodes",
@@ -366,9 +356,7 @@
           },
           {
             "group": " ",
-            "pages": [
-              "tooling/bridges/cross-chain-messaging"
-            ]
+            "pages": ["tooling/bridges/cross-chain-messaging"]
           }
         ]
       },
@@ -440,9 +428,7 @@
           },
           {
             "group": "Celo L2 Specs",
-            "pages": [
-              "infra-partners/specs"
-            ]
+            "pages": ["infra-partners/specs"]
           },
           {
             "group": "Integrate with Celo",
@@ -564,9 +550,7 @@
               "legacy/protocol/randomness",
               {
                 "group": "Contracts",
-                "pages": [
-                  "legacy/protocol/contracts/add-contract"
-                ]
+                "pages": ["legacy/protocol/contracts/add-contract"]
               }
             ]
           },
@@ -585,9 +569,7 @@
               "legacy/validator/voting",
               {
                 "group": "Run a Validator",
-                "pages": [
-                  "legacy/validator/run/mainnet"
-                ]
+                "pages": ["legacy/validator/run/mainnet"]
               },
               {
                 "group": "Key Management",
@@ -755,11 +737,11 @@
     },
     {
       "source": "/celo-codebase/protocol/consensus",
-      "destination": "/home/protocol/consensus"
+      "destination": "/home/protocol/security-council"
     },
     {
       "source": "/celo-codebase/protocol/consensus/index",
-      "destination": "/home/protocol/consensus"
+      "destination": "/home/protocol/security-council"
     },
     {
       "source": "/celo-codebase/protocol/consensus/locating-nodes",
@@ -767,7 +749,7 @@
     },
     {
       "source": "/celo-codebase/protocol/consensus/ultralight-sync",
-      "destination": "/home/protocol/consensus"
+      "destination": "/home/protocol/security-council"
     },
     {
       "source": "/celo-codebase/protocol/consensus/validator-set-differences",
@@ -2103,7 +2085,7 @@
     },
     {
       "source": "/protocol/consensus/index",
-      "destination": "/home/protocol/consensus"
+      "destination": "/home/protocol/security-council"
     },
     {
       "source": "/protocol/consensus/locating-nodes",
@@ -2111,7 +2093,7 @@
     },
     {
       "source": "/protocol/consensus/ultralight-sync",
-      "destination": "/home/protocol/consensus"
+      "destination": "/home/protocol/security-council"
     },
     {
       "source": "/protocol/consensus/validator-set-differences",

--- a/home/protocol/security-council.mdx
+++ b/home/protocol/security-council.mdx
@@ -1,40 +1,49 @@
 ---
-title: Consensus
-og:description: Introduction to the Celo consensus mechanism.
+title: Security Council
+og:description: Introduction to the Celo Security Council.
 ---
 
-Introduction to the Celo consensus mechanism. This page captures the key points about the proposed Security Council and its role in the Celo L2 Network.
+Introduction to the Celo Security Council. This page captures the key points about the proposed Security Council and its role in the Celo L2 Network.
 
 <Warning>
 As of block height 31,056,500 (March 26, 2025, 3:00 AM UTC), Celo is no longer a standalone Layer 1 blockchain—it is now an Ethereum Layer 2!
 Some documentation may be outdated as updates are in progress. If you encounter issues, please [file a bug report](https://github.com/celo-org/docs/issues/new/choose).
 
 For the most up-to-date information, refer to our [Celo L2 documentation](/build#celo-l2-mainnet).
+
 </Warning>
 
 <Note>
-This page is a work in progress based on the [proposal for the Celo L2’s Security Council](https://forum.celo.org/t/proposing-celo-l2s-security-council/10578/1). For updates make sure to refer to the [Celo Forum](https://forum.celo.org). 
+  This page is a work in progress based on the [proposal for the Celo L2's
+  Security
+  Council](https://forum.celo.org/t/proposing-celo-l2s-security-council/10578/1).
+  For updates make sure to refer to the [Celo Forum](https://forum.celo.org).
 </Note>
 
 ### Celo L2 Security Council Overview
 
-- **Purpose**: 
+- **Purpose**:
+
   - To decentralize the Celo L2 Network.
   - Manage key upgrades and security fixes.
 
 - **Responsibilities**:
-  - Upgrade L1 protocol contracts for Celo’s L2.
+
+  - Upgrade L1 protocol contracts for Celo's L2.
   - Modify designations for roles like sequencers, proposers, and challengers.
   - Execute urgent security fixes via hotfixes.
   - Act independently in urgent situations for the network's best interest.
 
 - **Decentralization Goals**:
+
   - Prevent any single entity from upgrading the system, modifying rollup state, or censoring transactions.
 
 - **Governance**:
+
   - Regular Governance Process for Celo Core Contracts and Community Fund remains unchanged.
 
 - **Proposed Multisig Structure**:
+
   - **2/2 Safe Multisig**:
     - Members: cLabs Multisig and Celo Community Security Council.
       - **cLabs Multisig**: 6/8 multisig.


### PR DESCRIPTION
This PR fixes issue #2087 by renaming the 'Consensus' section to 'Security Council' to accurately reflect that Celo is now an L2 and no longer has a consensus mechanism.

## Changes
- Renamed `home/protocol/consensus.mdx` to `home/protocol/security-council.mdx`
- Updated title and description to reflect Security Council instead of consensus mechanism
- Updated navigation references in `docs.json`
- Updated redirects to point to new security-council path

## Related Issue
Fixes #2087