### PR TITLE
docs: fix hundreds of broken internal links and typos across guides

### DIFF
--- a/_deprecated/cel2/faq.mdx
+++ b/_deprecated/cel2/faq.mdx
@@ -105,3 +105,9 @@ Dango was a short-lived testnet forked from Alfajores at block [24940100](https:
 Alfajores is a long running Celo network testnet that was [launched in July 2019](https://blog.celo.org/introducing-alfajores-1b162ebcb44d) and  upgraded to L2 in September 2024.
 
 See the [Alfajores network info here](/build-on-celo/network-overview).
+
+
+
+
+
+

--- a/_deprecated/cel2/index.mdx
+++ b/_deprecated/cel2/index.mdx
@@ -63,3 +63,9 @@ Following a successful Baklava upgrade, the Celo L2 Mainnet officially went live
 * [What's Changed?](/cel2/whats-changed/overview)
 * [Cel2 Code](https://github.com/celo-org/optimism)
 * [FAQ](/cel2/faq)
+
+
+
+
+
+

--- a/_deprecated/cel2/notices/celo-sepolia-launch.mdx
+++ b/_deprecated/cel2/notices/celo-sepolia-launch.mdx
@@ -88,3 +88,9 @@ Thank you to the first wave of our ecosystem partners supporting Celo Sepolia al
 ## Getting Help
 
 Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+
+
+
+
+
+

--- a/_deprecated/cel2/notices/eigenda-v2-upgrade.mdx
+++ b/_deprecated/cel2/notices/eigenda-v2-upgrade.mdx
@@ -72,3 +72,9 @@ The new proxy version will require to *add* the following new flags for each net
 
 The required configuration for each service can be found in our [Docker Compose Setup](https://github.com/celo-org/celo-l2-node-docker-compose), where every network has a corresponding `<network>.env` file.
 </Tip>
+
+
+
+
+
+

--- a/_deprecated/cel2/notices/isthmus-upgrade.mdx
+++ b/_deprecated/cel2/notices/isthmus-upgrade.mdx
@@ -64,3 +64,9 @@ Make the following checks to verify that your node is properly configured.
 - op-node and op-geth will log their configurations at startup
 - Check that the Isthmus time is set to `activation-timestamp` in the `op-node` startup logs
 - Check that the Isthmus time is set to `activation-timestamp` in the `op-geth` startup logs
+
+
+
+
+
+

--- a/_deprecated/cel2/notices/l2-migration.mdx
+++ b/_deprecated/cel2/notices/l2-migration.mdx
@@ -11,3 +11,9 @@ title: "Celo L2 Migration"
 The instructions for migrating a Celo node from Layer 1 to Layer 2 are outlined [in this guide](/cel2/operators/migrate-node). This process is necessary to transition your Celo L1 node to the new Celo L2 architecture based on the OP-Stack.
 
 If you wish to run a Celo L2 node from scratch, you can follow the instructions in the [Running a Celo Node](/cel2/operators/run-node) guide.
+
+
+
+
+
+

--- a/_deprecated/cel2/operators/architecture.mdx
+++ b/_deprecated/cel2/operators/architecture.mdx
@@ -17,3 +17,9 @@ The Execution Client is responsible for executing the block payloads it receives
 
 - To get your node up and running, start with the [operator guide](/cel2/operators/run-node).
 - If you've already got a Celo node up and running, check out [how to migrate it to a L2 node](/cel2/operators/migrate-node).
+
+
+
+
+
+

--- a/_deprecated/cel2/operators/migrate-node.mdx
+++ b/_deprecated/cel2/operators/migrate-node.mdx
@@ -272,3 +272,9 @@ If needed, you can also run the `check-db` script on its own as follows.
    ```
 
    This command takes in an optional `--fail-fast` flag that will make it exit at the first gap detected like it does when run via [celo-l2-node-docker-compose](https://github.com/celo-org/celo-l2-node-docker-compose). If the `--fail-fast` flag is not provided then the script will collect all the gaps it finds and print them out at the end.
+
+
+
+
+
+

--- a/_deprecated/cel2/operators/overview.mdx
+++ b/_deprecated/cel2/operators/overview.mdx
@@ -10,3 +10,9 @@ See the following document for more details:
 * [Celo L2 migration](/cel2/notices/l2-migration)
 
 See the guides for [running a node](/cel2/operators/run-node) or the guide on [how to migrate a L1 node](/cel2/operators/migrate-node).
+
+
+
+
+
+

--- a/_deprecated/cel2/operators/run-node.mdx
+++ b/_deprecated/cel2/operators/run-node.mdx
@@ -419,3 +419,9 @@ If you are hosting a public RPC node, please make sure the flag `--history.trans
 ## Getting Help
 
 Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+
+
+
+
+
+

--- a/_deprecated/integration/checklist.mdx
+++ b/_deprecated/integration/checklist.mdx
@@ -35,7 +35,7 @@ Please read more under [Custody](/integration/custody), but here is a shortened 
 
 Stable-value currencies, currently cUSD and cEUR, are contracts, `StableToken` and `StableTokenEUR` respectively, that can be accessed via the ERC20 interface. The native asset CELO can be accessed via the `GoldToken` ERC20 interface, or natively, similar to ETH on Ethereum.
 
-Addresses for those contracts can be found by querying the [registry](/developer/contractkit/contracts-wrappers-registry) or in the [Listing Guide](/integration/listings).
+Addresses for those contracts can be found by querying the [registry](/tooling/libraries-sdks/contractkit/contracts-wrappers-registry) or in the [Listing Guide](/integration/listings).
 
 ### Proof of Stake
 
@@ -84,3 +84,8 @@ Celo accounts can make claims to existing identities, some of which are verifiab
 ### Performance indicators
 
 Validator Groups and their validators can perform their duties differently and explorers should reflect that to allow voters to ensure an optimal validator set. While uptime in the form of block signatures by the validators ultimately affect rewards, explorers should also consider displaying [other metrics](/what-is-celo/about-celo-l1/validator/voting#choosing-a-validator-group) that impact the success of the Celo ecosystem, such as validators' performance in the identity protocol.
+
+
+
+
+

--- a/_deprecated/integration/cloud-hsm.mdx
+++ b/_deprecated/integration/cloud-hsm.mdx
@@ -121,3 +121,8 @@ const contractKit = newKitFromWeb3(this.web3, akvWallet);
 ## Summary
 
 You can now leverage a cloud HSM key to perform signing as a user or application. This improves both security and availability of your Celo keys. We also recommend enabling two-factor authentication across your Azure subscription and to leverage [Managed Service Identities](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) where possible.
+
+
+
+
+

--- a/_deprecated/integration/custody.mdx
+++ b/_deprecated/integration/custody.mdx
@@ -94,3 +94,8 @@ Some of these may occur as events rather than transactions on the network, and t
 ## Useful Tools
 
 Since monitoring balance changing operations is important to be able to display user balances properly, it can be helpful to use a tracing or reconciling system. [Celo Rosetta](https://github.com/celo-org/rosetta) is an RPC server that exposes an API to query the Celo blockchain, obtain balance changing operations, and construct airgapped transactions. With a special focus on getting balance change operations, Celo Rosetta provides an easy way to obtain changes that are not easily queryable using the celo-blockchain RPC.
+
+
+
+
+

--- a/_deprecated/integration/general.mdx
+++ b/_deprecated/integration/general.mdx
@@ -93,4 +93,9 @@ Compared to Ethereum transactions, Celo transactions have an additional optional
 To sign transactions, you have the following options:
 
 - Use the JSON-RPC [`sendTransaction`](https://github.com/ethereum/execution-apis/blob/c710097abda52b5a190d831eb8b1eddd3d28c603/tests/eth_sendRawTransaction/send-legacy-transaction.io) method to your node which would have the account in question unlocked. (Either manually or via a library such as `web3`)
-- Use [ContractKit's](/developer/contractkit/) local signing feature.
+- Use [ContractKit's](/tooling/libraries-sdks/contractkit/) local signing feature.
+
+
+
+
+

--- a/_deprecated/integration/index.mdx
+++ b/_deprecated/integration/index.mdx
@@ -24,3 +24,9 @@ Celo provides you with the tools to easily integrate DeFi into your existing mob
 - [Custody](/integration/custody)
 - [Listings](/integration/listings)
 - [Using a Cloud HSM](/integration/cloud-hsm)
+
+
+
+
+
+

--- a/_deprecated/integration/listings.mdx
+++ b/_deprecated/integration/listings.mdx
@@ -164,3 +164,8 @@ The Celo Protocol GitHub is located [here.](https://github.com/celo-org/)
 ### Audits
 
 All the security audits on the smart contracts, security and economics of the Celo Platform can be found [here](https://celo.org/audits).
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/node/run-alfajores.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/node/run-alfajores.mdx
@@ -111,3 +111,8 @@ true
 $ celocli account:new
 ...
 ```
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/node/run-baklava.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/node/run-baklava.mdx
@@ -111,3 +111,8 @@ true
 $ celocli account:new
 ...
 ```
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/node/run-mainnet.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/node/run-mainnet.mdx
@@ -121,3 +121,8 @@ true
 $ celocli account:new
 ...
 ```
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/consensus/index.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/consensus/index.mdx
@@ -23,3 +23,8 @@ Blocks in IBFT protocol are final, which means that there are no forks and any v
 ## Validators
 
 Celo’s consensus protocol is performed by nodes that are selected as validators. There is a maximum cap on the number of active validators that can be changed by governance proposal, which is currently set at 110 validators. The active validator set is determined via the proof-of-stake process and is updated at the end of each epoch, a fixed period of approximately one day.
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/consensus/locating-nodes.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/consensus/locating-nodes.mdx
@@ -34,3 +34,7 @@ The way that validators communicate their IP address to other validators is by p
 That message will contain `n` copies (where `n` is the total number of validators for the current epoch) of the sending validator's IP address where each copy is encrypted with the other validators' public key. Once a validator receives a gossiped _IstanbulAnnounce_ message, it will decrypt the encrypted IP address that was encrypted with its public key, and then establish a TCP connection to it. All consensus related messages will then sent via those direct TCP connections.
 
 When an epoch ends, a validator will establish new connections with any newly elected validator and disconnect from any removed validators. If the validator itself is removed from the new epoch's validator set, then it will disconnect with all the validators.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/consensus/validator-set-differences.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/consensus/validator-set-differences.mdx
@@ -14,3 +14,7 @@ This page describes the historical Celo Layer 1 blockchain. It is useful for und
 ## Computing Set Differences
 
 The validator set for a given epoch is elected at the end of the last block of the previous epoch. The new validator set is written to the **extradata** field of the header for this block. As an optimization, the validator set is encoded as the difference between the new and previous validator sets. Nodes that join the network are able to compute the validator set for the current epoch by starting with the initial validator set \(encoded in the genesis block\) and iteratively applying these diffs.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/contracts/add-contract.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/contracts/add-contract.mdx
@@ -26,3 +26,8 @@ The test directory is organized the same way as the contracts directory so feel 
 <Tip>
 Some build issues can be resolved by simply deleting the `build` and the `typechain` folder. Don’t forget to run `yarn build` once again.
 </Tip>
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/encrypted-cloud-backup.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/encrypted-cloud-backup.mdx
@@ -111,3 +111,8 @@ Within 30 guesses, an attacker has a 5-9% chance of guessing a users first-choic
 In order to address this, it is highly recommended to block the most easily guessed PINs.
 One way to do this is to block PINs that are most popular.
 A suggested implementation, which is [implemented by the Valora wallet](https://github.com/valora-inc/wallet/blob/3940661c40d08e4c5db952bd0abeaabb0030fc7a/packages/mobile/src/pincode/authentication.ts#L56-L108), is to create a blocklist from the top 25k most frequently seen PINs in the HIBP Passwords dataset.
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/index.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/index.mdx
@@ -52,3 +52,7 @@ The attestation service is a simple Node.js service that validators run to send 
 ### Future improvements to privacy
 
 Celo is committed to meet the privacy needs of its users. More details about areas for future research can be found in [Privacy Research](/legacy/protocol/identity/privacy-research)
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/metadata.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/metadata.mdx
@@ -37,7 +37,7 @@ In the future ContractKit may support other types of claim, including:
 
 ## Handling Metadata
 
-You can interact with metadata files easily through the [CLI](/cli/account), or in your own scripts, tools or DApps via [ContractKit](/developer/contractkit/). Most commands require a node being available under `http://localhost:8545` to make view calls, and to modify metadata files, you'll need the relevant account to be unlocked to sign the files.
+You can interact with metadata files easily through the [CLI](/cli/account), or in your own scripts, tools or DApps via [ContractKit](/tooling/libraries-sdks/contractkit/). Most commands require a node being available under `http://localhost:8545` to make view calls, and to modify metadata files, you'll need the relevant account to be unlocked to sign the files.
 
 You can create an empty metadata file with:
 
@@ -68,3 +68,7 @@ Then, anyone can lookup your claims and verify them by running:
 ```bash
 celocli account:get-metadata $ACCOUNT_ADDRESS
 ```
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis-domain-sequential-delay-domain.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis-domain-sequential-delay-domain.mdx
@@ -12,3 +12,8 @@ The motivating use case is allowing wallets to define how often users can attemp
 A full specification of the Sequential Delay Domain is available in an extension to CIP-40.
 
 - [Sequential Delay Domain Specification](https://github.com/celo-org/celo-proposals/blob/master/CIPs/CIP-0040/sequentialDelayDomain.md)
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis-domain.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis-domain.mdx
@@ -48,3 +48,8 @@ When it is ready for review, contact a [CIP editor](https://github.com/celo-org/
 
 Implementing a new Domain type, which includes new rate limiting to be enforced by the ODIS operators, requires an upgrade to the ODIS server implementation.
 Once the new domain type is standardized, this implementation can be written and deployed to the staging and production ODIS service operators.
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis-use-case-key-hardening.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis-use-case-key-hardening.mdx
@@ -40,3 +40,8 @@ In addition to using ODIS to harden passwords chosen by users, it is recommended
 Password filtering, blocking the user from setting a password which may be weak, can greatly improve the quality of a user's password and prevent it being broken by guessing the most common passwords (e.g. "password").
 [NIST 800-63](https://pages.nist.gov/800-63-3/sp800-63-3.html) recommends that passwords should be checked against a list of known compromised passwords, such as [HIBP Passwords](https://haveibeenpwned.com/Passwords).
 Additional research has found other [practical techniques for increasing the strength of passwords chosen by users](https://www.andrew.cmu.edu/user/nicolasc/publications/Tan-CCS20.pdf).
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis-use-case-phone-number-privacy.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis-use-case-phone-number-privacy.mdx
@@ -38,3 +38,8 @@ Since blockchain accounts and phone numbers are not naturally Sybil-resistant (i
 
 The requirements for these factors are configured to make it prohibitively expensive to scrape large quantities of phone numbers while still allowing typical user flows to remain unaffected.
 In particular, it should be possible for a user to look up their contacts in order to send them payments.
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/odis.mdx
@@ -114,3 +114,8 @@ Both services leverage the [Celo Threshold BLS library](https://github.com/celo-
 The combiner and signers maintain some minimal state in a SQL database, mainly related to quota tracking.
 
 For storage of the BLS signing key, the signers currently support three cloud-based keystores: Azure Key Vault, AWS Secret Manager, and Google Secret Manager.
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/privacy-research.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/privacy-research.mdx
@@ -14,3 +14,8 @@ One downside to this identity protocol is that knowledge of a phone number can l
 As with most public blockchains \(e.g. Bitcoin, Ethereum\), transactions and smart contracts calls on Celo are public for everyone to see. This means that if a user wants to map the hash of their phone number to their wallet address, people with knowledge of that user's phone number will be able to see their transactions and balances.
 
 To address this issue, the cLabs team, [Matterlabs](https://matterlabs.dev) and other esteemed zk-SNARK cryptographers and Celo community members are working to create a framework that makes it easy to create gas-efficient tokens that offer Zcash-like privacy, using a shared anonymity pool. Such an implementation could allow wallets to use the default identity mode easily without the risk that someone with your phone number could see your balance and transaction history.  */}
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/identity/smart-contract-accounts.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/identity/smart-contract-accounts.mdx
@@ -60,7 +60,7 @@ To look up a wallet using a phone number:
 3. Use the on-chain identifier to get the account address
 4. Use the account address to get the wallet address (EOA)
 
-The first two steps are covered extensively in [this guide](/developer/contractkit/odis).
+The first two steps are covered extensively in [this guide](/tooling/libraries-sdks/contractkit/odis).
 
 To get the account address (step 3) you can use the [Attestation contract method `lookupAccountsForIdentifier`](https://github.com/celo-org/celo-monorepo/blob/e6fdaf798a662ffe2c12f9a74b28e0fa1c1f8101/packages/sdk/contractkit/src/wrappers/Attestations.ts#L472).
 
@@ -81,3 +81,8 @@ This data can't be signed by the `msg.sender` since it's originating from a cont
 ## Implementation
 
 The implementation of the meta-transaction wallet can be [found here](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/common/MetaTransactionWallet.sol).
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/becoming-a-validator.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/becoming-a-validator.mdx
@@ -13,3 +13,8 @@ To participate in the network, an operator must put up a slashable commitment of
 Any account that meets the minimum stake and notice period requirements can register as a validator. By doing so, the locked funds on that account become ‘at risk’: a fraction of the stake can be slashed automatically for an evolving set of misbehaviors. In addition, the community can use governance proposals to slash funds, which avoids having to anticipate and encode in the protocol every possible misbehavior. As long as the CELO staked for a validator account is not slashed, it’s eligible to earn rewards like any other Locked Gold account.
 
 A validator joins a validator group by affiliating itself with it. However, to avoid untrusted or malicious validators joining a group, the validator group must accept the affiliation. Once done, the validator is added to the list of validators in the group. A validator can remove itself from a validator group at any time. Changes only take effect at the next subsequent election, so if the validator is currently participating in consensus, it’s expected to do so until the end of the epoch in which it deregisters itself.
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards-locked-gold.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards-locked-gold.mdx
@@ -41,3 +41,7 @@ where $$rr$$ is the reward rate or voting yield, $$vf$$ is the voting fraction c
 Adjusting the on-target reward rate to account for under- or over-spending against the target schedule gives a baseline reward, essentially the percentage increase for a unit of Locked CELO voting for a group eligible for rewards.
 
 The reward for activated Locked CELO voting for a given group is determined as follows. First, if the group elected no validators in the current epoch, rewards are zero. Otherwise, the baseline reward rate factors in two deductions. It is multiplied by the slashing penalty for the group, and by the average epoch uptime score for validators in the group elected in the current epoch. Finally, the group's activated pool of Locked CELO is increased by this rate.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards-validator.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards-validator.mdx
@@ -65,3 +65,7 @@ When a validator is slashed, reduced rewards may lead other validators in the sa
 Validator groups are compensated by taking a share of the rewards allocated to validators. Validator groups set a **group share** rate when they register, and can change that at any time. The protocol automatically deducts this share, sending that portion of the epoch rewards to the validator group of which they were a member at the time of the last election.
 
 Since the sum of a validator’s reward and its validator group’s reward are the same regardless of the ‘group share’ that the group chooses, no side-channel collusion is possible to avoid deductions for downtime or previous slashing.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/epoch-rewards.mdx
@@ -48,3 +48,7 @@ There is a target schedule for the release of CELO epoch rewards. The proposed t
 The total **actual rewards** paid out at the end of a given epoch result from multiplying the total on-target rewards with a `Rewards Multiplier`. This adjustment factor is a function of the percentage deviation of the remaining epoch rewards from the target epoch rewards remaining. It evaluates to `1` if the remaining epoch rewards are at the target and to smaller \(or larger\) than `1` if the remaining rewards are below \(or above, respectively\) the target. This creates a drag towards the target schedule.
 
 The sensitivity of the adjustment factor to the percentage deviation from the target are governable parameters: one for an underspend, one for an overspend.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/index.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/index.mdx
@@ -63,3 +63,7 @@ In Celo blockchain:
 - [`consensus/istanbul/backend/backend.go`](https://github.com/celo-org/celo-blockchain/blob/master/consensus/istanbul/backend/backend.go) performs validator elections in the last block of the epoch and calculates the new [validator set diff](/what-is-celo/about-celo-l1/protocol/consensus/validator-set-differences).
 
 - [`consensus/istanbul/backend/pos.go`](https://github.com/celo-org/celo-blockchain/blob/master/consensus/istanbul/backend/pos.go) is called in the last block of the epoch to process validator uptime scores and make epoch rewards.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/locked-gold.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/locked-gold.mdx
@@ -73,3 +73,7 @@ The governance participants who cannot actively participate to vote on governanc
 Currently, participants can only delegate to 10 other delegatees.
 
 Participants can follow the steps [here](/what-is-celo/using-celo/protocol/governance/voting-in-governance#vote-delegation) to perform delegation using CeloCLI.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/penalties.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/penalties.mdx
@@ -46,3 +46,7 @@ In exchange for sending a transaction which initiates a successful provable slas
 ### **Governed**
 
 For misbehavior which is harder to formally classify and requires some off-chain knowledge, slashing can be performed via [governance proposals](/what-is-celo/using-celo/protocol/governance/overview/). These conditions are important for preventing nuanced validator attacks.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/validator-elections.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/validator-elections.mdx
@@ -57,3 +57,7 @@ Then, in the first iteration, the algorithm assigns the first seat to the group 
 ### Number of Active Validators
 
 There is a minimum target and a maximum cap on the number of active validators that may be selected. If the minimum target is not reached, the election aborts and no change is made to the validator set this epoch.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/pos/validator-groups.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/pos/validator-groups.mdx
@@ -65,3 +65,7 @@ Both validators and validator groups can use [Accounts Metadata](/legacy/protoco
 ## Dissolving of a Validator Group
 
 There is a 180 day unlocking period for Celo locked when creating a validator group.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/randomness.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/randomness.mdx
@@ -53,3 +53,8 @@ contract Example is UsingRegistryV2 {
     }
 }
 ```
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/stability/adding-stable-assets.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/stability/adding-stable-assets.mdx
@@ -87,3 +87,7 @@ Adding a new stable asset involves updating many parts of the tooling, such as:
 <Info>
 [^2] Please note this example proposal also includes freezing, this is because, at the time of writing (22-march-2021), the tooling for proposing a contract release doesn't support freezing those contracts on the same proposal. Proposals shall not be modified manually given that the tool is meant to run verifications.
 </Info>
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/stability/doto.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/stability/doto.mdx
@@ -58,3 +58,7 @@ For a more detailed explanation, read the article [Zooming in on the Celo Expans
 ## Multi-mento Deployment
 
 Many instances of mento can be deployed in parallel for different stable assets. Currently, `cEUR` and `cUSD` live side-by-side, with independent buckets and oracle reports (although both of them are using the same `SortedOracles` instance). They all fill the CELO bucket with funds from the Reserve, but not necessarily at the same time.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/stability/granda-mento.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/stability/granda-mento.mdx
@@ -54,3 +54,7 @@ The approver multi-sig that is ultimately responsible for approving an exchange 
 | Zviad Metreveli | WOTrust                       | `zm #1073`                | `0xE267D978037B89db06C6a5FcF82fAd8297E290ff` |
 | human           | OpenCelo                      | `human #6811`             | `0x91f2437f5C8e7A3879e14a75a7C5b4CccC76023a` |
 | Deepak Nuli     | Kresko                        | `Deepak \| Kresko#3647`   | `0x099f3F5527671594351E30B48ca822cc90778a11` |
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/stability/index.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/stability/index.mdx
@@ -34,3 +34,7 @@ The Celo protocol's stability mechanism comprises the following:
 - [Oracles](/what-is-celo/about-celo-l1/protocol/stability/oracles)
 - [Stability Fees](/what-is-celo/about-celo-l1/protocol/stability/stability-fees)
 - [Adding Stable Tokens](/what-is-celo/about-celo-l1/protocol/stability/adding-stable-assets)
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/stability/oracles.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/stability/oracles.mdx
@@ -29,3 +29,7 @@ To ensure the oracle's value doesn't go stale due to inactive reporters, any rep
 ## Celo-Oracle Repository
 
 You can find more information about the technical specification of the Celo Oracles feeding data to the reserve in the [GitHub repository here](https://github.com/celo-org/celo-oracle).
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/stability/stability-fees.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/stability/stability-fees.mdx
@@ -61,3 +61,7 @@ The `updateInflationFactor` modifier is called by the following functions:
 - `transferFrom`
 - `transfer`
 - `debitFrom`
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/erc20-transaction-fees.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/erc20-transaction-fees.mdx
@@ -19,7 +19,7 @@ The protocol maintains a governable allowlist of smart contract addresses which 
 
 ## Allowlisted Gas Fee Addresses
 
-To obtain a list of the gas fee addresses that have been allowlisted using [Celo's Governance Process](/what-is-celo/using-celo/protocol/governance/overview), you can run the `getCurrencies` method on the `FeeCurrencyDirectory` contract. All other notable Mainnet core smart contracts are listed [here](/contracts/core-contracts#celo-mainnet).
+To obtain a list of the gas fee addresses that have been allowlisted using [Celo's Governance Process](/what-is-celo/using-celo/protocol/governance/overview), you can run the `getCurrencies` method on the `FeeCurrencyDirectory` contract. All other notable Mainnet core smart contracts are listed [here](/tooling/contracts/core-contracts#celo-mainnet).
 
 ### Tokens with Adapters
 
@@ -81,3 +81,7 @@ let tx = {
 <Note>
 To get details about the underlying token of the adapter you can call `adaptedToken` function on the adapter address, which will return the underlying token address.
 </Note>
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/escrow.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/escrow.mdx
@@ -30,3 +30,7 @@ The recipient of an escrowed payment can choose to withdraw their payment assumi
 ## Revoking & Reclaiming
 
 Alice sends Bob an escrowed payment. Let’s say Bob never withdraws it, or worse, the temporary private key he needs to withdraw the payment gets lost or sent to the wrong person. For this purpose, Celo’s protocol also allows for senders to reclaim any unclaimed escrowed payment that they sent. After an escrowed payment's `expirySeconds` \(set by the sender on creation of the payment\) has passed, the sender of the payment can revoke the payment and reclaim their funds with just the paymentId.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/gas-pricing.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/gas-pricing.mdx
@@ -40,3 +40,7 @@ When the client wants to ensure that their transaction is processed quickly, the
 ## Transaction Fee Recipients
 
 The required portion of gas fee, known as the **base**, is set as `base = gas_price_minimum * gas_used` and is sent to the Gas Fee Handler smart contract, which is controlled by governance and handles how the fees are used (e.g., for carbon removal and burning). The rest of the gas fee, known as the **tip**, is rewarded to the validator that proposes the block. Block producers only receive the tip and not the base of the gas fee, which means that they do not have an incentive to artificially inflate the gas price minimum by flooding the network with transactions.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/index.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/index.mdx
@@ -21,3 +21,7 @@ Transactions in the Celo protocol include payments, contract calls, and other op
 
 - Gas prices must meet or exceed the [gas price minimum](/what-is-celo/about-celo-l1/protocol/transaction/gas-pricing).
 - Gas fees may be paid in currencies other than the native CELO.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/native-currency.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/native-currency.mdx
@@ -24,3 +24,7 @@ The native currency in the Celo protocol, CELO, conforms to the ERC20 interface.
 
 As the native currency of the protocol, CELO, much like Ether, can still be sent directly via transactions by specifying a non-zero “value”, bypassing the ERC20 interface.
 </Tip>
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/transaction-types.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/transaction-types.mdx
@@ -467,3 +467,8 @@ const walletClient = createWalletClient({
     </Tab>
 
 </Tabs>
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/tx-comment-encryption.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/protocol/transaction/tx-comment-encryption.mdx
@@ -43,3 +43,7 @@ A 128 bit randomly generated session key, sk, is generated and used to symmetric
 5.  The MAC key, km, is SHA-256 of the second 128 bits of k
 6.  Encrypt the plaintext symmetrically with AES-128-CTR using ke, km, and a random iv
 7.  Return ephemPubKey \| AES-128-CTR-HMAC\(ke, km, plaintext\) where the public key needs to be uncompressed \(current limitation with decrypt\).
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/celo-foundation-voting-policy.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/celo-foundation-voting-policy.mdx
@@ -160,3 +160,8 @@ If you would like to keep up-to-date with all the news happening in the Celo com
 
 You can add the [Celo Signal public calendar](https://calendar.google.com/calendar/u/0/embed?src=c_9su6ich1uhmetr4ob3sij6kaqs@group.calendar.google.com) as well which has relevant dates.
 </Note>
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/celo-website.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/celo-website.mdx
@@ -2,3 +2,7 @@
 title: Celo Website
 url: https://celo.org
 ---
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/devops-best-practices.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/devops-best-practices.mdx
@@ -33,3 +33,7 @@ That way, in the event of a node or instance failure on your validator box, whic
 ### Kubernetes
 
 We are working on getting a Kubernetes recommended specification and will update this section once we have a recommended spec. If you are using Kubernetes with your validator node, feel free to submit a PR to update this section with your setup.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/discord.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/discord.mdx
@@ -2,3 +2,7 @@
 title: Celo Discord
 url: https://discord.com/invite/celo
 ---
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/index.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/index.mdx
@@ -41,3 +41,8 @@ Not ready to become a Celo Validator? [Learn more about Celo](/).
 <Tip>
 For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/key-management/detailed.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/key-management/detailed.mdx
@@ -160,3 +160,7 @@ celocli account:show $LOCKED_GOLD_ACCOUNT
 # You can also look up account info via the authorized signer
 celocli account:show $SIGNER_TO_AUTHORIZE
 ```
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/key-management/key-rotation.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/key-management/key-rotation.mdx
@@ -68,3 +68,7 @@ The newly authorized keys will only take effect in the next epoch, so the instan
 </Warning>
 
 5. Shut down the validator instance with the now obsolete signer key.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/key-management/summary.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/key-management/summary.mdx
@@ -35,3 +35,7 @@ For more details on a specific key type, please see the more detailed sections b
 <Warning>
 A Locked CELO Account may have at most one authorized signer of each type at any time. Once a signer is authorized, the only way to deauthorize that signer is to authorize a new signer that has never previously been used as an authorized signer or Locked CELO Account. It follows then that a newly deauthorized signer cannot be reauthorized.
 </Warning>
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/monitoring.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/monitoring.mdx
@@ -154,3 +154,7 @@ Celo adds specific functions around consensus:
 Prometheus exporter that scrapes downtime and meta information for a specified validator signer address from the Celo blockchain. All data is collected from a blockchain node via RPC.
 
 {/* ## Monitoring Network Health, Elections, and Accounts */}
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/node-upgrade.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/node-upgrade.mdx
@@ -167,3 +167,7 @@ Release 1.2.0 is backwards incompatible in the Validator and Proxy connection. V
 </Danger>
 
 With multi-proxy, you can upgrade proxies one by one or can add newly synced proxies with the latest Docker image and can remove the old proxies. If upgrading the proxies in place, a rolling upgrade is recommended as the validator will re-assign direct connections as proxies are added and removed. These re-assignments will allow the validator to continue to participate in consensus.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/proxy.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/proxy.mdx
@@ -32,3 +32,7 @@ There are two ways to specify the proxy information to a validator. It can be do
 - `istanbul.proxies` can be used on the validator to list the validator's proxy set
 
 - `istanbul.proxiedValidators` can be used on the proxies to list the proxied validators
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/run/mainnet.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/run/mainnet.mdx
@@ -23,3 +23,7 @@ While other Validator Groups will exist on the Celo Network, the fastest way to 
 Because of the importance of Validator security and availability, Validators are expected to run a "proxy" node in front of each Validator node. In this setup, the Proxy node connects with the rest of the network, and the Validator node communicates only with the Proxy, ideally via a private network.
 
 [Read more about Celo's mission and why you may want to become a Validator.](https://medium.com/celoorg/calling-all-chefs-become-a-celo-validator-c75d1c2909aa) - This article still uses the term Celo Gold which is the deprecated name for the Celo native asset, which now is referred to simply as "Celo" or preferably "CELO".
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/security.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/security.mdx
@@ -30,3 +30,7 @@ Beyond the RPC interface, Celo nodes and services have other interfaces that act
 
 - **DDoS protection:** Protected public endpoints from a DDoS attack is highly recommended to allow valid requests to be served
 - **Whitelist endpoints:** The attestation service exposes a limited number of paths to function correctly. You could use a reverse proxy to reject paths that don't match them.
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/troubleshooting-faq.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/troubleshooting-faq.mdx
@@ -57,3 +57,7 @@ You can then run celocli and point it to your local geth.ipc file:
 # Check if node is synced using celocli
 sudo celocli node:synced --node geth.ipc
 ```
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/validator-explorer.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/validator-explorer.mdx
@@ -107,3 +107,7 @@ celocli account:get-metadata $CELO_VALIDATOR_GROUP_RG_ADDRESS
 ```
 
 If everything went well, you should now have your group and validator associated with each other and with your associated domain!
+
+
+
+

--- a/_deprecated/what-is-celo/about-celo-l1/validator/voting.mdx
+++ b/_deprecated/what-is-celo/about-celo-l1/validator/voting.mdx
@@ -94,3 +94,7 @@ The estimate is calculated based on past performance.
 
 Vido is a block visualization and monitoring suite for Mainnet and the Baklava testnet.
 It shows missed blocks and downtime for the Validator group set and subscribable metrics to get alerted if your Validator is no longer signing.
+
+
+
+

--- a/_deprecated/what-is-celo/celo-website.mdx
+++ b/_deprecated/what-is-celo/celo-website.mdx
@@ -2,3 +2,8 @@
 title: Celo Website
 url: https://celo.org
 ---
+
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/builders.mdx
+++ b/_deprecated/what-is-celo/joining-celo/builders.mdx
@@ -26,3 +26,8 @@ There are several ways to get started as a builder on Celo:
 * **Apply for an Accelerator**: Check out [Celo Camp](https://www.celocamp.com/), the accelerator focused on the Celo ecosystem. If you are not yet at that stage, they also offer [Startup Pathway](https://startup-pathway.mykajabi.com/) a program, that leads you through your first steps to becoming a founder.
 
 * **Access Exclusive Resources**: [Register as a Celo Builder](https://docs.google.com/forms/d/e/1FAIpQLSemO5Kbf8fzq70AtiZEPRkk040MmpmmyhRqeurAwuVWUg63tQ/viewform) to gain access to resources and support available to active builders on Celo.
+
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/code-of-conduct.mdx
+++ b/_deprecated/what-is-celo/joining-celo/code-of-conduct.mdx
@@ -2,3 +2,7 @@
 title: Code of Conduct
 url: https://celo.org/code-of-conduct
 ---
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/cip-contributors.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/cip-contributors.mdx
@@ -25,3 +25,7 @@ CIP template:
 <Tip>
 For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/code-contributors.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/code-contributors.mdx
@@ -75,3 +75,7 @@ You contributed to Celo! Congratulations and thanks!
 <Tip>
 If you've commented on an existing issue and have been waiting for a reply, or want to message us for any other reason, please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/documentation-contributors.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/documentation-contributors.mdx
@@ -84,3 +84,7 @@ When creating or editing documentation:
 <Tip>
 For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/overview.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/overview.mdx
@@ -47,3 +47,7 @@ Share your Celo experience through blog posts:
 <Tip>
 For questions or discussions, use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/release-process/attestation-service.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/release-process/attestation-service.mdx
@@ -150,3 +150,7 @@ If the issue is exploitable and mitigations are not readily available, a patch s
 ## Vulnerability Disclosure
 
 Vulnerabilities in Attestation Service releases should be disclosed according to the [security policy](https://github.com/celo-org/celo-blockchain/blob/master/SECURITY.md).
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/release-process/base-cli-contractkit-dappkit-utils.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/release-process/base-cli-contractkit-dappkit-utils.mdx
@@ -93,3 +93,7 @@ Vulnerabilities in any of these releases should be disclosed according to the [s
 
 - Celocli
 - All the packages under the ["SDK" folder](https://github.com/celo-org/developer-tooling/tree/master/packages/sdk)
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/release-process/blockchain-client.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/release-process/blockchain-client.mdx
@@ -99,3 +99,7 @@ If the issue is exploitable and mitigations are not readily available, a patch s
 ## Vulnerability Disclosure
 
 Vulnerabilities in `celo-blockchain` releases should be disclosed according to the [security policy](https://github.com/celo-org/celo-blockchain/blob/master/SECURITY.md)e
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/release-process/index.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/release-process/index.mdx
@@ -16,3 +16,7 @@ It is critical that updates to the Celo platform can be released on a regular ba
 - [Blockchain Client](/what-is-celo/joining-celo/contributors/release-process/blockchain-client)
 - [CeloCLI and ContractKit](/what-is-celo/joining-celo/contributors/release-process/base-cli-contractkit-dappkit-utils)
 - [Attestation Service](/what-is-celo/joining-celo/contributors/release-process/attestation-service)
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/contributors/release-process/smart-contracts.mdx
+++ b/_deprecated/what-is-celo/joining-celo/contributors/release-process/smart-contracts.mdx
@@ -241,8 +241,8 @@ Stakeholders can use the `env-tests` package in `celo-monorepo` to run an automa
 
 Verification of smart contracts should be done both on https://celoscan.io/ and https://celo.blockscout.com/.
 
-1. [Update your Smart Contract on celoscan](/developer/verify/celoscan)
-2. [Update your Smart Contract on Blockscout](/developer/verify/blockscout)
+1. [Update your Smart Contract on celoscan](/tooling/contract-verification/celoscan)
+2. [Update your Smart Contract on Blockscout](/tooling/contract-verification/blockscout)
 
 ### Performance
 
@@ -501,3 +501,8 @@ None
 <Warning>
 Work in progress
 </Warning>
+
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/daos.mdx
+++ b/_deprecated/what-is-celo/joining-celo/daos.mdx
@@ -88,3 +88,8 @@ Reach out to them on <ColoredText>[Twitter](https://x.com/Celo_India)</ColoredTe
 By participating in a Regional DAO, you can contribute to the growth of the Celo ecosystem in your local area. Each DAO offers opportunities for developers, entrepreneurs, and community members to collaborate, share ideas, and drive impactful projects. Explore your region’s DAO to see how you can get involved and help further Celo’s mission of financial inclusion and sustainability.
 
 For more information on how to join or collaborate with a Regional DAO, visit the <ColoredText>[Celo Forum](https://forum.celo.org/)</ColoredText> or <ColoredText>[Discord](https://discord.com/invite/celo)</ColoredText> to connect with the community.
+
+
+
+
+

--- a/_deprecated/what-is-celo/joining-celo/index.mdx
+++ b/_deprecated/what-is-celo/joining-celo/index.mdx
@@ -62,3 +62,8 @@ Ask questions, find answers, and connect with the community.
 - [Celo Builder Telegram](https://t.me/buildwithcelo)
 - [Celo Forum](https://forum.celo.org/)
 - [Celo Subreddit](https://www.reddit.com/r/celo/)
+
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/bridged_tokens/tokens.mdx
+++ b/_deprecated/what-is-celo/using-celo/bridged_tokens/tokens.mdx
@@ -22,3 +22,8 @@
 | WLD | Worldcoin | L1: [0x163f8C2467924be0ae7B5347228CABF260318753](https://etherscan.io/token/0x163f8C2467924be0ae7B5347228CABF260318753)<br />L2: [0x88c400d871829e381b53b55eee79145b4287461a](https://celoscan.io/token/0x88c400d871829e381b53b55eee79145b4287461a) |
 | WBTC | Wrapped BTC | L1: [0x2260fac5e5542a773aa44fbcfedf7c193bc2c599](https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599)<br />L2: [0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D](https://celoscan.io/token/0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D) |
 | WETH | Wrapped Ether | L1: [0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2)<br />L2: [0xD221812de1BD094f35587EE8E174B07B6167D9Af](https://celoscan.io/token/0xD221812de1BD094f35587EE8E174B07B6167D9Af) |
+
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/index.mdx
+++ b/_deprecated/what-is-celo/using-celo/index.mdx
@@ -63,3 +63,7 @@ For questions, comments, and discussions, connect with the Celo community:
 <Tip>
 New to Celo? Start with the [Celo Overview](/home) for a complete introduction to the platform.
 </Tip>
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/manage/asset.mdx
+++ b/_deprecated/what-is-celo/using-celo/manage/asset.mdx
@@ -60,3 +60,7 @@ When you have sufficient balance, you can send Mento stablecoins such as cUSD to
 ```shell
 celocli transfer:dollars --from $CELO_ACCOUNT_ADDRESS --to <RECIPIENT-ADDRESS> --value <VALUE-TO-TRANSFER>
 ```
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/manage/exchange.mdx
+++ b/_deprecated/what-is-celo/using-celo/manage/exchange.mdx
@@ -30,3 +30,7 @@ Because of slippage and the Mento price occasionally changing according to a pri
 [celo-exchange-bot](https://github.com/celo-org/celo-exchange-bot) is intended to be operated by the exchanger as it requires access to the source key, which must own CELO funds to exchange and is the account that performs the exchanges. Operating the bot requires some technical knowledge of dealing with keys and operating infrastructure. Currently, the bot requires the source key to be an HSM in Azure's Key Vault service. Information on how to use an Azure Cloud HSM can be found [here](/integration/cloud-hsm).
 
 See the repository's [README](https://github.com/celo-org/celo-exchange-bot) for information on building a Docker image and configurating the bot. Example infrastructure using Azure's [Container Instances](https://azure.microsoft.com/en-gb/services/container-instances/) is also provided in the repository [here](https://github.com/celo-org/celo-exchange-bot/tree/master/infrastructure-example). While the bot does require Azure Key Vault to be used for the source key and the provided example infrastructure is ran on Azure, the bot itself can be ran from anywhere as long as it's able to access its Azure Key Vault Cloud HSM.
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/manage/release-gold.mdx
+++ b/_deprecated/what-is-celo/using-celo/manage/release-gold.mdx
@@ -115,3 +115,7 @@ What happens if there is a bug in the `ReleaseGold` contract?
 What is the distribution ratio?
 
 - Some grants are subject to “distribution schedules,” which control the release of funds outside of a traditional vesting schedule for legal reasons. This schedule is controlled by the `distributionRatio` and is adjustable by the `releaseOwner`.
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/manage/self-custody.mdx
+++ b/_deprecated/what-is-celo/using-celo/manage/self-custody.mdx
@@ -433,3 +433,7 @@ celocli releasecelo:withdraw --contract $CELO_RG_ADDRESS --useLedger --value <CE
 ```
 
 To vote with any CELO in your beneficiary account, you'll want to register it as a Locked CELO Account, authorize a new vote signing key for it, then lock CELO.
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/celo-token.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/celo-token.mdx
@@ -46,3 +46,7 @@ Regardless of the transfer method, CELO tokens **reflect in both the native acco
 ---
 
 By enabling seamless interoperability between native and ERC-20 transactions, **CELO remains highly flexible within the Ethereum and Celo ecosystems** without requiring additional conversion steps.
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/consensus.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/consensus.mdx
@@ -44,3 +44,8 @@ This page is a work in progress based on the [proposal for the Celo L2’s Secur
 - **Security Standards**:
   - Follow Optimism multisig security policy.
   - Allow nested multisigs if all signers adhere to the security policy.
+
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/escrow.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/escrow.mdx
@@ -30,3 +30,7 @@ The recipient of an escrowed payment can choose to withdraw their payment assumi
 ## Revoking & Reclaiming
 
 Alice sends Bob an escrowed payment. Let's say Bob never withdraws it, or worse, the temporary private key he needs to withdraw the payment gets lost or sent to the wrong person. For this purpose, Celo's protocol also allows for senders to reclaim any unclaimed escrowed payment that they sent. After an escrowed payment's `expirySeconds` \(set by the sender on creation of the payment\) has passed, the sender of the payment can revoke the payment and reclaim their funds with just the paymentId.
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/governance/governable-parameters.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/governance/governable-parameters.mdx
@@ -28,3 +28,7 @@ List of governable parameters and governance restrictions on Celo.
 - How nodes sync
 - How nodes store their data locally
 - Most parameters that affect the blockchain
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/governance/governance-toolkit.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/governance/governance-toolkit.mdx
@@ -36,3 +36,7 @@ The curent Celo Governance Guardians (formerly known as CGP Editors), actively p
   * Eric [Celo Forum](https://forum.celo.org/u/ericnakagawa), [Twitter](https://x.com/ericnakagawa)
   * Anna [Celo Forum](https://forum.celo.org/u/annaalexa), [Twitter](https://x.com/AnnaAlexaK)
   
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/governance/overview.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/governance/overview.mdx
@@ -93,3 +93,8 @@ If a proposal is not accepted, a cool-off period is required for additional conv
 2. If a proposal is rejected and has a majority of NO votes, the proposal is moved back to the discussion stage and may be submitted for a vote after receiving approval from the Governance Guardians and waiting for 28 days.
 
 **Note**: In the event that a proposal meets or exceeds quorum, but is not approved in time, the proposers should be able to re-submit as soon as they are able. This would happen in a rare situations when approvers are unable to approve in the 72 hour window following a referendum vote.
+
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/governance/smart-contracts-upgrades.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/governance/smart-contracts-upgrades.mdx
@@ -24,3 +24,7 @@ The current process requires approval from both an approver multisig and the Sec
 ## Celo Blockchain Software Upgrades
 
 Some changes cannot be made through the onchain governance process alone. Examples include changes to the underlying consensus protocol and changes which would result in a hard-fork.
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/governance/voting-in-governance-using-mondo.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/governance/voting-in-governance-using-mondo.mdx
@@ -36,3 +36,6 @@ To stay up-to-date with all governance activities and proposals:
 - Follow discussions on the [Celo Forum](https://forum.celo.org/) in the Governance category
 
 For more comprehensive information about Celo's governance system, see the [Governance Overview](/what-is-celo/using-celo/protocol/governance/overview) and [Voting in Governance](/what-is-celo/using-celo/protocol/governance/voting-in-governance) guides.
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/governance/voting-in-governance.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/governance/voting-in-governance.mdx
@@ -180,3 +180,6 @@ To stay up-to-date with all governance activities and proposals:
 - Follow discussions on the [Celo Forum](https://forum.celo.org/) in the Governance category
 
 For more comprehensive information about Celo's governance system, see the [Governance Overview](/what-is-celo/using-celo/protocol/governance/overview) and [Voting in Governance](/what-is-celo/using-celo/protocol/governance/voting-in-governance) guides.
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/index.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/index.mdx
@@ -32,3 +32,7 @@ There are a number of substantial changes and additions have been made in servic
 - [Stability Mechanism - Mento](https://www.mento.org/)
 - [Transactions](/what-is-celo/about-celo-l1/protocol/transaction)
 - [Identity - Self](https://self.xyz/)
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/transaction/overview.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/transaction/overview.mdx
@@ -28,7 +28,7 @@ gas currencies incur approximately 50,000 additional gas units.
 Celo allows paying gas fees in currencies other than the native currency. The tokens that can be
 used to pay gas fees are controlled via governance and the list of tokens allowed is maintained in
 FeeCurrencyWhitelist.sol. Fee abstraction on Celo works with EOAs. No paymaster required! Learn all
-about [fee abstraction](/developer/fee-abstraction).
+about [fee abstraction](/tooling/overview/fee-abstraction).
 
 ## Transaction Fee Allocation Post-L2 Transition
 
@@ -51,3 +51,6 @@ This reallocation ensures that transaction fees are utilized effectively to main
 ## Conclusion
 
 Celo's transition to L2 introduces significant changes to gas pricing and transaction fee allocation, aligning with the network's goals of sustainability, user accessibility, and robust operational support. These adjustments are designed to enhance the overall efficiency and resilience of the Celo ecosystem.
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/transaction/transaction-types.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/transaction/transaction-types.mdx
@@ -487,3 +487,7 @@ const walletClient = createWalletClient({
     </Tab>
 
 </Tabs>
+
+
+
+

--- a/_deprecated/what-is-celo/using-celo/protocol/transaction/tx-comment-encryption.mdx
+++ b/_deprecated/what-is-celo/using-celo/protocol/transaction/tx-comment-encryption.mdx
@@ -36,3 +36,6 @@ A 128 bit randomly generated session key, sk, is generated and used to symmetric
 5. The MAC key, km, is SHA-256 of the second 128 bits of k
 6. Encrypt the plaintext symmetrically with AES-128-CTR using ke, km, and a random iv
 7. Return ephemPubKey \| AES-128-CTR-HMAC\(ke, km, plaintext\) where the public key needs to be uncompressed \(current limitation with decrypt\).
+
+
+

--- a/build-on-celo/build-on-minipay/code-library.mdx
+++ b/build-on-celo/build-on-minipay/code-library.mdx
@@ -406,3 +406,9 @@ async function requestTransfer(tokenAddress, transferValue, tokenDecimals, recei
 ```
 
 {/* prettier-ignore-end */}
+
+
+
+
+
+

--- a/build-on-celo/build-on-minipay/deeplinks.mdx
+++ b/build-on-celo/build-on-minipay/deeplinks.mdx
@@ -12,3 +12,9 @@ To trigger or redirect a MiniPay user to the add cash screen inside Minipay you 
 <Frame>
 ![add cash minipay deeplink](/img/developer/build-on-minipay/deeplinks/add-cash-deeplink.gif)
 </Frame>
+
+
+
+
+
+

--- a/build-on-celo/build-on-minipay/overview.mdx
+++ b/build-on-celo/build-on-minipay/overview.mdx
@@ -32,3 +32,9 @@ Install the new MiniPay standalone app for [Android](https://play.google.com/sto
 
 - **Raising Funding?** Reach out to team@verda.ventures with a deck and/or product demo.
 - **Still Building?** Register your project for [Build With Celo: Proof-of-Ship](https://www.celopg.eco/programs/proof-of-ship-s1) for monthly rewards.
+
+
+
+
+
+

--- a/build-on-celo/build-on-minipay/prerequisites/ngrok-setup.mdx
+++ b/build-on-celo/build-on-minipay/prerequisites/ngrok-setup.mdx
@@ -40,3 +40,9 @@ The output looks something like this.
 </Frame>
 
 You can use the highlighted url to launch the localhost dApp on the [MiniPay's Site Tester](/build-on-celo/build-on-minipay/quickstart#test-your-mini-app-inside-minipay).
+
+
+
+
+
+

--- a/build-on-celo/build-on-minipay/quickstart.mdx
+++ b/build-on-celo/build-on-minipay/quickstart.mdx
@@ -235,3 +235,9 @@ This will provide you with a public URL that tunnels to your localhost.
 For a more in depth guide, check out the official [ngrok setup](/build-on-celo/build-on-minipay/prerequisites/ngrok-setup).
 
 - **Test in MiniPay:** Copy the provided ngrok URL and use it inside the MiniPay app to test your DApp.
+
+
+
+
+
+

--- a/build-on-celo/build-on-socialconnect.mdx
+++ b/build-on-celo/build-on-socialconnect.mdx
@@ -48,3 +48,9 @@ To dive deeper into SocialConnect, explore the following sections in the documen
 - **Protocol**: Detailed information about the protocol's architecture and components.
 - **Examples**: Practical examples, including a Next.js example.
 - **Contracts**: Information about the smart contracts used in SocialConnect.
+
+
+
+
+
+

--- a/build-on-celo/build-with-ai/8004.mdx
+++ b/build-on-celo/build-with-ai/8004.mdx
@@ -275,3 +275,9 @@ ERC-8004 works seamlessly with Celo's ecosystem:
 - [x402](/build-on-celo/build-with-ai/x402) - Payment layer for AI agents
 - [Agent Skills](/build-on-celo/build-with-ai/agent-skills) - Modular agent capabilities
 - [MCP Servers](/build-on-celo/build-with-ai/mcp/index) - Connect agents to data and tools
+
+
+
+
+
+

--- a/build-on-celo/build-with-ai/agent-skills.mdx
+++ b/build-on-celo/build-with-ai/agent-skills.mdx
@@ -307,3 +307,9 @@ Want to add a new skill? See the [contribution guide](https://github.com/celo-or
 - [ERC-8004](/build-on-celo/build-with-ai/8004) - Trust layer for AI agents
 - [x402](/build-on-celo/build-with-ai/x402) - Payment layer for AI agents
 - [Celo MCP](/build-on-celo/build-with-ai/mcp/celo-mcp) - MCP server for Celo blockchain
+
+
+
+
+
+

--- a/build-on-celo/build-with-ai/mcp/celo-mcp.mdx
+++ b/build-on-celo/build-with-ai/mcp/celo-mcp.mdx
@@ -199,3 +199,9 @@ Start the MCP server directly:
 python -m celo_mcp.server
 
 ```
+
+
+
+
+
+

--- a/build-on-celo/build-with-ai/mcp/index.mdx
+++ b/build-on-celo/build-with-ai/mcp/index.mdx
@@ -7,7 +7,7 @@ og:description: Learn about the Model Context Protocol and how to use Celo-speci
 
 ## Celo specific MCPs:
 
-- [Celo MPC Server](/build/build-with-ai/mcp/celo-mcp)
+- [Celo MPC Server](/build-on-celo/build-with-ai/mcp/celo-mcp)
   - Chain Info
   - Governance Proposals
 
@@ -51,3 +51,9 @@ Explore existing MCP server implementations:
 
 - [Official MCP Documentation](https://modelcontextprotocol.io/introduction)
 - [MCP Community Forum](https://community.modelcontextprotocol.io)
+
+
+
+
+
+

--- a/build-on-celo/build-with-ai/overview.mdx
+++ b/build-on-celo/build-with-ai/overview.mdx
@@ -115,3 +115,9 @@ await sendUSDCWithFeeAbstraction("0xRecipient...", parseUnits("1", 6));
 | USDC | Sepolia | [`0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B`](https://sepolia.celoscan.io/address/0x2f25deb3848c207fc8e0c34035b3ba7fc157602b) | [`0x4822e58de6f5e485eF90df51C41CE01721331dC0`](https://sepolia.celoscan.io/address/0x4822e58de6f5e485eF90df51C41CE01721331dC0) |
 
 For the full guide — including gas estimation, CIP-64 transaction types, and CLI usage — see [Implementing Fee Abstraction](/tooling/overview/fee-abstraction).
+
+
+
+
+
+

--- a/build-on-celo/build-with-ai/usecases.mdx
+++ b/build-on-celo/build-with-ai/usecases.mdx
@@ -43,3 +43,9 @@ Do you have an AI Agent project, tool, or hackathon you want to share? Add it to
     - Check out [Proof-of-Ship on Karma](https://www.karmahq.xyz/community/celo) for a list of projects deployed on Celo this month.
 
 
+
+
+
+
+
+

--- a/build-on-celo/build-with-ai/vibe-coding.mdx
+++ b/build-on-celo/build-with-ai/vibe-coding.mdx
@@ -7,7 +7,7 @@ og:description: Learn how to set up your environment for Vibe Coding and discove
 
 Vibe Coding refers to an approach to software development where you use chat agents inside your IDE and build an application mainly by using prompts. This guide introduces you to a curated collection of tools that can significantly improve your development process, from full-stack application development to code editing and research.
 
-Watch a quick intro to Vibe Coding with the Celo MCP Servers. You can find out more about them in the [MCP section](/build/build-with-ai/mcp/index).
+Watch a quick intro to Vibe Coding with the Celo MCP Servers. You can find out more about them in the [MCP section](/build-on-celo/build-with-ai/mcp/index).
 
 <iframe
   src="https://www.youtube.com/embed/QOCO1G8cJyI"
@@ -106,4 +106,10 @@ Tools that help you gather and process information effectively, mainly MCPs. Add
 
 ## Additional Resources
 
-- [MCP Server Guide](/build/build-with-ai/mcp/index) - Learn more about MCP integration
+- [MCP Server Guide](/build-on-celo/build-with-ai/mcp/index) - Learn more about MCP integration
+
+
+
+
+
+

--- a/build-on-celo/build-with-ai/x402.mdx
+++ b/build-on-celo/build-with-ai/x402.mdx
@@ -338,3 +338,9 @@ app.get("/articles/:id", async (req, res) => {
 - [ERC-8004](/build-on-celo/build-with-ai/8004) - Trust layer for AI agents
 - [Agent Skills](/build-on-celo/build-with-ai/agent-skills) - Modular agent capabilities
 - [Fee Abstraction](/tooling/overview/fee-abstraction) - Pay gas with stablecoins on Celo
+
+
+
+
+
+

--- a/build-on-celo/build-with-defi.mdx
+++ b/build-on-celo/build-with-defi.mdx
@@ -88,3 +88,9 @@ Oracles are a crucial part to get real time price information on tokens. Speed i
 Developers and entrepreneurs can leverage Celo's infrastructure to build next-generation stablecoin applications.
 
 By building on Celo, you're not just creating DeFi applications, you're enabling real-world financial inclusion and empowering users globally.
+
+
+
+
+
+

--- a/build-on-celo/build-with-farcaster.mdx
+++ b/build-on-celo/build-with-farcaster.mdx
@@ -402,3 +402,9 @@ After building your MiniApp, you'll need to publish it so users can discover and
 - [Farcaster MiniApp SDK Reference](https://miniapps.farcaster.xyz/docs/sdk)
 - [Celo Composer](https://github.com/celo-org/celo-composer)
 - [Wagmi Documentation](https://wagmi.sh)
+
+
+
+
+
+

--- a/build-on-celo/build-with-local-stablecoin.mdx
+++ b/build-on-celo/build-with-local-stablecoin.mdx
@@ -36,3 +36,9 @@ Celo supports a diverse range of fiat-referenced stablecoins designed for differ
 | **BRLA Digital** | [BRLA](https://brla.digital/)                                           | Brazil-based stablecoin                           | [0xfecb3f7c54e2caae9dc6ac9060a822d47e053760](https://celoscan.io/token/0xfecb3f7c54e2caae9dc6ac9060a822d47e053760)  |  - |
 | **COPM**         | [Minteo](https://minteo.com/)                                           | Fiat-backed Colombian Peso Stablecoin             |  [0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606](https://celoscan.io/token/0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606) | -  |
 | **G$**           | [GoodDollar](https://www.gooddollar.org/)                               | UBI-focused stablecoin for financial inclusion    | [0x62b8b11039fcfe5ab0c56e502b1c372a3d2a9c7a](https://celoscan.io/token/0x62b8b11039fcfe5ab0c56e502b1c372a3d2a9c7a)  | -  |
+
+
+
+
+
+

--- a/build-on-celo/build-with-self.mdx
+++ b/build-on-celo/build-with-self.mdx
@@ -95,3 +95,9 @@ Self has introduced a points program that incentivizes consistent, secure use:
 Join the [Self Builder Group](https://t.me/selfprotocolbuilder) on Telegram for community support and updates.
 
 For Celo-specific integrations, visit the [Celo Discord](https://discord.com/invite/celo) and ask in the #build-with-celo channel.
+
+
+
+
+
+

--- a/build-on-celo/build-with-thirdweb/celo-nft-drop-tutorial.mdx
+++ b/build-on-celo/build-with-thirdweb/celo-nft-drop-tutorial.mdx
@@ -82,3 +82,9 @@ Once the project is running, you’ll see the first NFT displayed along with a d
 2. Sign up to join [Proof of Ship](https://celo-devs.beehiiv.com/subscribe).
 3. You can win up to **`5k USDm`** + Track Bounties.
 4. Build with **`Celo`**.
+
+
+
+
+
+

--- a/build-on-celo/build-with-thirdweb/one-click quickstart.mdx
+++ b/build-on-celo/build-with-thirdweb/one-click quickstart.mdx
@@ -95,3 +95,9 @@ the mint button, 0.1 Celo will be paid.
 3. You can win up to **`5k USDm`** + Track Bounties.
 4. Build with **`Celo`**.
 
+
+
+
+
+
+

--- a/build-on-celo/build-with-thirdweb/overview.mdx
+++ b/build-on-celo/build-with-thirdweb/overview.mdx
@@ -27,3 +27,9 @@ Using Thirdweb is recommended because it eliminates the complexity of Web3 devel
 
 * [Thirdweb main page](https://thirdweb.com/?utm_source=celo&utm_medium=documentation&utm_campaign=chain_docs)
 * [Thirdweb Docs](https://portal.thirdweb.com/?utm_source=celo&utm_medium=documentation&utm_campaign=chain_docs)
+
+
+
+
+
+

--- a/build-on-celo/cel2-architecture.mdx
+++ b/build-on-celo/cel2-architecture.mdx
@@ -64,3 +64,9 @@ Celo L2 incorporates EigenDA as its Data Availability (DA) layer:
 - Ensures transaction data remains accessible and cost-efficient
 - Operates separately from the execution and settlement layers
 - Contributes to lower transaction costs and improved scalability
+
+
+
+
+
+

--- a/build-on-celo/fund-your-project.mdx
+++ b/build-on-celo/fund-your-project.mdx
@@ -64,3 +64,9 @@ If you want to add another ecosystem-led funding program, [edit this page](https
 ## Get Funding Updates
 
 Stay up to date with the latest funding opportunities by [joining our newsletter](https://embeds.beehiiv.com/eeadfef4-2f0c-45ce-801c-b920827d5cd2).
+
+
+
+
+
+

--- a/build-on-celo/index.mdx
+++ b/build-on-celo/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Building dApps on Celo
-og:description: A guide  for building on Celo.
+og:description: A guide for building on Celo.
 sidebarTitle: "Getting started"
 ---
 import {ColoredText} from "/snippets/ColoredText.jsx";
 
-Celo was created to enable real-world uses cases on Ethereum.
+Celo was created to enable real-world use cases on Ethereum.
 
 Whether you're building your first dApp or looking to integrate an existing protocol onto Celo, we have all the resources and tools you need to get started.
 
@@ -13,24 +13,24 @@ Whether you're building your first dApp or looking to integrate an existing prot
 
 ## Why Build on Celo?
 
-- **EVM Compatibile:** Celo is fully EVM-compatible, offering the same development experience as Ethereum with improved scalability and lower costs.
-- **Fast Transactions:** After the migrations to an L2 Celo now has a **1-second block finality** compared to formerly 5 seconds.
-- **Easy, Low-Cost Payments:** Celo's seamless payment infrastructure, including [Fee Abstraction](/developer/fee-abstraction), **sub-cent fees**, and **native stablecoins**, enables simple and affordable transactions.
+- **EVM Compatible:** Celo is fully EVM-compatible, offering the same development experience as Ethereum with improved scalability and lower costs.
+- **Fast Transactions:** After the migration to an L2, Celo now has a **1-second block finality** compared to formerly 5 seconds.
+- **Easy, Low-Cost Payments:** Celo's seamless payment infrastructure, including [Fee Abstraction](/tooling/overview/fee-abstraction), **sub-cent fees**, and **native stablecoins**, enables simple and affordable transactions.
 - **Global Reach:** Celo provides access to more than **8 million real-world users** with some dApps having more than **200,000 DAUs**.
 
 ## Getting Started
 
 <Columns cols={2}>
-    <Card title="Quickstart" href="/build/quickstart" arrow>
+    <Card title="Quickstart" href="/build-on-celo/quickstart" arrow>
         Quickstart with Celo Composer CLI
     </Card>
-    <Card title="Deploy on Celo" href="/developer/deploy/index" arrow>
+    <Card title="Deploy on Celo" href="/tooling/dev-environments/index" arrow>
         Deploy a smart contract on Celo
     </Card>
     <Card title="Faucet" href="https://faucet.celo.org/celo-sepolia" arrow>
         Receive testnet funds
     </Card>
-    <Card title="Tooling" href="/developer" arrow>
+    <Card title="Tooling" href="/tooling/overview/index" arrow>
         Explore developer tooling
     </Card>
 </Columns>
@@ -57,7 +57,7 @@ The Celo L2 testnet, Alfajores, went live! This provides a testing environment f
 
 ### October 2024: Code Freeze and Audits
 
-The core dev team froze all feature development by mid-October and underwent a thorough external audit. The result is available at https://celo.org/audits.
+The core dev team froze all feature development by mid-October and underwent a thorough external audit. The result is available at [celo.org/audits](https://celo.org/audits).
 
 ### 20th February, 2025: Baklava L2 Testnet Launch
 
@@ -74,3 +74,9 @@ Following a successful Baklava upgrade, the Celo L2 Mainnet officially went live
 * [What's Changed?](/legacy/overview)
 * [Cel2 Code](https://github.com/celo-org/optimism)
 * [FAQ](/legacy/faq)
+
+
+
+
+
+

--- a/build-on-celo/launch-checklist.mdx
+++ b/build-on-celo/launch-checklist.mdx
@@ -93,3 +93,9 @@ Make your dapp discoverable by reporting it on these platforms:
 - [ ] **Keep Docs Updated**: Update documentation as features evolve
 - [ ] **Changelog**: Maintain a changelog for transparency
 - [ ] **Migration Guides**: Provide guides for breaking changes if applicable
+
+
+
+
+
+

--- a/build-on-celo/network-overview.mdx
+++ b/build-on-celo/network-overview.mdx
@@ -18,7 +18,7 @@ Overview of Celo Mainnet and the Celo Sepolia Testnet.
 | RPC Nodes                  | <ul><li>[List of RPC providers](network/node/overview#as-a-service)</li><li>[Celo L2 Mainnet Day 1 Node and RPC providers](/developer#node-and-rpc-providers)</li></ul> |
 | RPC Endpoint (best effort) | https://forno.celo.org <br/> Note: [Forno](/tooling/nodes/forno#celo-mainnet) is rate limited, as your usage increases consider options that can provide the desired level of support (SLA).                          |
 | Block Explorers            | <ul><li>[https://explorer.celo.org](https://explorer.celo.org)</li><li>[https://celoscan.io](https://celoscan.io)</li></ul>                                                                               |
-| Bridge Link                | [List of bridges](/developer/bridges/bridges)                                                                                                                                                             |
+| Bridge Link                | [List of bridges](/tooling/bridges/bridges)                                                                                                                                                             |
 
 :::
 
@@ -54,4 +54,11 @@ Try Celo's new developer testnet on Ethereum Sepolia.
 <Warning>
 The Celo Sepolia Testnet is designed for testing and experimentation by developers. Its tokens hold no real world economic value. The testnet software will be upgraded on a regular basis. This will erase your accounts, their balance and your transaction history. You may encounter bugs and limitations with the software and documentation.
 </Warning>
+
+
+
+
+
+
+
 

--- a/build-on-celo/nightfall.mdx
+++ b/build-on-celo/nightfall.mdx
@@ -436,3 +436,9 @@ Nightfall testnet on Celo Sepolia is for development and testing purposes only. 
 3. Follow the [Running the Client on Celo Sepolia](#running-the-client-on-celo-sepolia) guide to set up your development environment
 4. Join the [Celo community](https://chat.celo.org) to ask questions
 5. Start building your private payment application on testnet
+
+
+
+
+
+

--- a/build-on-celo/quickstart.mdx
+++ b/build-on-celo/quickstart.mdx
@@ -88,7 +88,7 @@ Optimized for building dApps that integrate with the MiniPay mobile wallet, with
 npx @celo/celo-composer@latest create --template minipay
 ```
 
-Checkout [minipay docs](/build/build-on-minipay/overview) to learn more about it.
+Check out [minipay docs](/build-on-celo/build-on-minipay/overview) to learn more about it.
 
 ### AI Chat App
 
@@ -183,3 +183,9 @@ Join the [Celo Discord server](https://discord.com/invite/celo). Reach out in th
 ## Resources
 
 - [GitHub Repository](https://github.com/celo-org/celo-composer)
+
+
+
+
+
+

--- a/build-on-celo/scaling-your-app.mdx
+++ b/build-on-celo/scaling-your-app.mdx
@@ -296,3 +296,9 @@ Use Grafana for analytics and logs:
 - [Vercel AI SDK](https://sdk.vercel.ai/) - AI SDK for JavaScript/TypeScript
 - [Sentry Documentation](https://docs.sentry.io/) - Error monitoring and performance tracking
 - [Grafana Documentation](https://grafana.com/docs/) - Analytics and observability platform
+
+
+
+
+
+

--- a/build-on-celo/support.mdx
+++ b/build-on-celo/support.mdx
@@ -28,3 +28,9 @@ For the latest updates, sign up for the <ColoredText>[DevDesk Mailing List](http
 - [Celo specification](https://specs.celo.org/)
 - [Transaction types on Celo](https://github.com/celo-org/txtypes)
 - [Celo Forum](https://forum.celo.org/)
+
+
+
+
+
+

--- a/contribute-to-celo/builders.mdx
+++ b/contribute-to-celo/builders.mdx
@@ -21,3 +21,9 @@ There are several ways to get started as a builder on Celo:
 * **Apply for Grants**: Celo has grants programs, like [Prezenti](https://www.prezenti.xyz/) and [Celo Public Goods](https://www.celopg.eco/) which supports projects that align with its mission to provide financial services to the next billion people.
 
 * **Apply for an Accelerator**: Check out [Celo Camp](https://www.celocamp.com/), the accelerator focused on the Celo ecosystem. If you are not yet at that stage, they also offer [Startup Pathway](https://startup-pathway.mykajabi.com/) a program, that leads you through your first steps to becoming a founder.
+
+
+
+
+
+

--- a/contribute-to-celo/code-of-conduct.mdx
+++ b/contribute-to-celo/code-of-conduct.mdx
@@ -2,3 +2,8 @@
 title: Code of Conduct
 url: https://celo.org/code-of-conduct
 ---
+
+
+
+
+

--- a/contribute-to-celo/community-rpc-nodes/community-rpc-node.mdx
+++ b/contribute-to-celo/community-rpc-nodes/community-rpc-node.mdx
@@ -44,7 +44,7 @@ Confirm successful reward distribution by checking for `ValidatorEpochPaymentDis
 For accounting purposes, you can:
 
 - Query Celo nodes for `ValidatorEpochPaymentDistributed` events.
-- Query the [EpochManager contract](/contracts/core-contracts) for `validatorPendingPayments` to view total allocated payments.
+- Query the [EpochManager contract](/tooling/contracts/core-contracts) for `validatorPendingPayments` to view total allocated payments.
 
 ### Group Commission Settings
 
@@ -57,3 +57,9 @@ celocli validatorgroup:show $CELO_GROUP_ADDRESS
 ```
 
 Update commission settings with the [celocli validatorgroup:commission](/cli/validatorgroup) command.
+
+
+
+
+
+

--- a/contribute-to-celo/community-rpc-nodes/how-it-works.mdx
+++ b/contribute-to-celo/community-rpc-nodes/how-it-works.mdx
@@ -47,3 +47,9 @@ Elections are handled my smart contracts, and as such can be changed through Cel
 - [`Election.sol`](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/Election.sol) manages Locked Gold voting and epoch rewards and runs Validator Elections.
 
 - [`EpochManager.sol`](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts-0.8/common/EpochManager.sol) handles the epoch processing logic, including starting and finishing epoch transitions, reward calculations, and validator elections through permissionless functions.
+
+
+
+
+
+

--- a/contribute-to-celo/community-rpc-nodes/penalties.mdx
+++ b/contribute-to-celo/community-rpc-nodes/penalties.mdx
@@ -56,3 +56,8 @@ Providers with uptime below 20% for 7 days are slashed.
 - [Overview of rewards and epochs in L2](https://specs.celo.org/smart_contract_updates_from_l1.html#overview-of-rewards-and-epochs-in-l2)
 - [Scoring](https://specs.celo.org/smart_contract_updates_from_l1.html#scoring)
 - [Slashing](https://specs.celo.org/smart_contract_updates_from_l1.html#slashing)
+
+
+
+
+

--- a/contribute-to-celo/community-rpc-nodes/registering-as-rpc-node.mdx
+++ b/contribute-to-celo/community-rpc-nodes/registering-as-rpc-node.mdx
@@ -327,3 +327,9 @@ celocli lockedcelo:show $CELO_NODE_ADDRESS
 Active validators receive USDm rewards based on their validator score, calculated as part of the L2 epoch rewards process (see `EpochRewards.calculateTargetEpochRewards()`). For more details, refer to the [L2 Epoch Rewards documentation](/home/protocol/epoch-rewards/index).
 
 For reward claiming instructions, see [Claiming Rewards](./community-rpc-node#claiming-rewards).
+
+
+
+
+
+

--- a/contribute-to-celo/community-rpc-nodes/validator-rpc-faq.mdx
+++ b/contribute-to-celo/community-rpc-nodes/validator-rpc-faq.mdx
@@ -62,3 +62,8 @@ You can make the group ineligible for election by removing all its members, afte
 If validators choose to not run the RPC nodes after the transition, rewards will eventually drop to zero for the voters and the validators.
 </Accordion>
 </AccordionGroup>
+
+
+
+
+

--- a/contribute-to-celo/contributors/cip-contributors.mdx
+++ b/contribute-to-celo/contributors/cip-contributors.mdx
@@ -25,3 +25,8 @@ CIP template:
 <Tip>
 For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+
+

--- a/contribute-to-celo/contributors/code-contributors.mdx
+++ b/contribute-to-celo/contributors/code-contributors.mdx
@@ -73,3 +73,8 @@ You contributed to Celo! Congratulations and thanks!
 <Tip>
 If you've commented on an existing issue and have been waiting for a reply, or want to message us for any other reason, please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+
+

--- a/contribute-to-celo/contributors/documentation-contributors.mdx
+++ b/contribute-to-celo/contributors/documentation-contributors.mdx
@@ -74,3 +74,8 @@ When creating or editing documentation:
 <Tip>
 For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+
+

--- a/contribute-to-celo/contributors/overview.mdx
+++ b/contribute-to-celo/contributors/overview.mdx
@@ -38,3 +38,8 @@ For effective contributions:
 <Tip>
 For questions or discussions, use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+
+

--- a/contribute-to-celo/daos.mdx
+++ b/contribute-to-celo/daos.mdx
@@ -88,3 +88,9 @@ Reach out to them on <ColoredText>[Twitter](https://x.com/Celo_India)</ColoredTe
 By participating in a Regional DAO, you can contribute to the growth of the Celo ecosystem in your local area. Each DAO offers opportunities for developers, entrepreneurs, and community members to collaborate, share ideas, and drive impactful projects. Explore your region’s DAO to see how you can get involved and help further Celo’s mission of financial inclusion and sustainability.
 
 For more information on how to join or collaborate with a Regional DAO, visit the <ColoredText>[Celo Forum](https://forum.celo.org/)</ColoredText> or <ColoredText>[Discord](https://discord.com/invite/celo)</ColoredText> to connect with the community.
+
+
+
+
+
+

--- a/contribute-to-celo/index.mdx
+++ b/contribute-to-celo/index.mdx
@@ -57,3 +57,9 @@ Ask questions, find answers, and connect with the community.
 - [Celo Builder Telegram](https://t.me/buildwithcelo)
 - [Celo Forum](https://forum.celo.org/)
 - [Celo Subreddit](https://www.reddit.com/r/celo/)
+
+
+
+
+
+

--- a/contribute-to-celo/release-process/attestation-service.mdx
+++ b/contribute-to-celo/release-process/attestation-service.mdx
@@ -150,3 +150,8 @@ If the issue is exploitable and mitigations are not readily available, a patch s
 ## Vulnerability Disclosure
 
 Vulnerabilities in Attestation Service releases should be disclosed according to the [security policy](https://github.com/celo-org/celo-blockchain/blob/master/SECURITY.md).
+
+
+
+
+

--- a/contribute-to-celo/release-process/base-cli-contractkit-dappkit-utils.mdx
+++ b/contribute-to-celo/release-process/base-cli-contractkit-dappkit-utils.mdx
@@ -88,3 +88,9 @@ Vulnerabilities in any of these releases should be disclosed according to the [s
 - @celo/mobile - Dappkit relies on this
 - Celocli
 - All the packages under the ["SDK" folder](https://github.com/celo-org/developer-tooling/tree/master/packages/sdk) -- These all rely on each other quite a bit, so triple-check that these packages weren’t affected by a change in another.
+
+
+
+
+
+

--- a/contribute-to-celo/release-process/blockchain-client.mdx
+++ b/contribute-to-celo/release-process/blockchain-client.mdx
@@ -99,3 +99,8 @@ If the issue is exploitable and mitigations are not readily available, a patch s
 ## Vulnerability Disclosure
 
 Vulnerabilities in `celo-blockchain` releases should be disclosed according to the [security policy](https://github.com/celo-org/celo-blockchain/blob/master/SECURITY.md).
+
+
+
+
+

--- a/contribute-to-celo/release-process/index.mdx
+++ b/contribute-to-celo/release-process/index.mdx
@@ -14,3 +14,8 @@ It is critical that updates to the Celo platform can be released on a regular ba
 - [Blockchain Client](/contribute-to-celo/release-process/blockchain-client)
 - [CeloCLI and ContractKit](/contribute-to-celo/release-process/base-cli-contractkit-dappkit-utils)
 - [Attestation Service](/contribute-to-celo/release-process/attestation-service)
+
+
+
+
+

--- a/contribute-to-celo/release-process/smart-contracts.mdx
+++ b/contribute-to-celo/release-process/smart-contracts.mdx
@@ -241,8 +241,8 @@ Stakeholders can use the `env-tests` package in `celo-monorepo` to run an automa
 
 Verification of smart contracts should be done both on https://celoscan.io/ and https://celo.blockscout.com/.
 
-1. [Update your Smart Contract on celoscan](/developer/verify/celoscan)
-2. [Update your Smart Contract on Blockscout](/developer/verify/blockscout)
+1. [Update your Smart Contract on celoscan](/tooling/contract-verification/celoscan)
+2. [Update your Smart Contract on Blockscout](/tooling/contract-verification/blockscout)
 
 ### Performance
 
@@ -501,3 +501,9 @@ None
 <Warning>
 Work in progress
 </Warning>
+
+
+
+
+
+

--- a/home/bridged-tokens/bridges.mdx
+++ b/home/bridged-tokens/bridges.mdx
@@ -55,3 +55,8 @@ In addition to token bridges, there are also protocols that enable cross-chain m
 - [Wormhole](https://wormhole.com/)
 - [Layer Zero](https://layerzero.network/)
 - [Axelar Network](https://axelar.network/)
+
+
+
+
+

--- a/home/bridged-tokens/native-ETH-bridging.mdx
+++ b/home/bridged-tokens/native-ETH-bridging.mdx
@@ -46,3 +46,9 @@ When using Superbridge, this entire process is abstracted away from the user.
 | L2 WETH Address (WETH_ADDRESS_REMOTE on Celo Sepolia) | [`0x2cE73DC897A3E10b3FF3F86470847c36ddB735cf`](https://sepolia.celoscan.io/address/0x2cE73DC897A3E10b3FF3F86470847c36ddB735cf) |
 | L1 Standard Bridge Proxy (STANDARD_BRIDGE_ADDRESS) | [`0xec18a3c30131a0db4246e785355fbc16e2eaf408`](https://sepolia.etherscan.io/address/0xec18a3c30131a0db4246e785355fbc16e2eaf408) |
 | Deployed SuperBridgeETHWrapper Address (on Ethereum Sepolia) | [`0x523e358dFd0c4e98F3401DAc7b1879445d377e37`](https://sepolia.etherscan.io/address/0x523e358dFd0c4e98F3401DAc7b1879445d377e37) |
+
+
+
+
+
+

--- a/home/celo.mdx
+++ b/home/celo.mdx
@@ -146,3 +146,8 @@ description: "Celo is a leading Ethereum L2. As the frontier chain for global im
 <Tip>
   New to Celo? Start with the [Celo Overview](/home) for a complete introduction to the platform.
 </Tip>
+
+
+
+
+

--- a/home/exchanges.mdx
+++ b/home/exchanges.mdx
@@ -26,3 +26,8 @@ Be sure you understand and review the risks when swapping assets.
 
 - [Ubeswap](https://app.ubeswap.org/#/swap)
 - [Mento](https://app.mento.org/) - Good for stablecoin swaps
+
+
+
+
+

--- a/home/gas-fees.mdx
+++ b/home/gas-fees.mdx
@@ -26,3 +26,9 @@ Bridge assets from other blockchains to CELO using:
 - [Squid Router V2](https://v2.app.squidrouter.com/?chains=10%2C42220&tokens=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee%2C0x471ece3750da237f93b8e339c536989b8978a438)
 - [SmolRefeul](https://smolrefuel.com/?outboundChain=42220) (Gas-free)
 - [Other Bridges](/home/bridged-tokens/bridges)
+
+
+
+
+
+

--- a/home/history.mdx
+++ b/home/history.mdx
@@ -126,3 +126,9 @@ Ethereum debuts as a Proof-of-Work blockchain, introducing smart contracts but f
 For a deeper understanding of Celo's evolution and the technical foundations behind it, check out our <ColoredText>[white papers](https://celo.org/papers)</ColoredText>. These documents cover the innovations and decisions that have shaped Celo.  
 
 <ColoredText>[Read our White Papers](https://celo.org/papers)</ColoredText>
+
+
+
+
+
+

--- a/home/index.mdx
+++ b/home/index.mdx
@@ -47,3 +47,9 @@ For questions, comments, and discussions, connect with the Celo community:
 
 - [Celo Forum](https://forum.celo.org/)
 - [Discord](https://chat.celo.org/)
+
+
+
+
+
+

--- a/home/manage/asset.mdx
+++ b/home/manage/asset.mdx
@@ -60,3 +60,8 @@ When you have sufficient balance, you can send Mento stablecoins such as USDm to
 ```shell
 celocli transfer:dollars --from $CELO_ACCOUNT_ADDRESS --to <RECIPIENT-ADDRESS> --value <VALUE-TO-TRANSFER>
 ```
+
+
+
+
+

--- a/home/manage/exchange.mdx
+++ b/home/manage/exchange.mdx
@@ -30,3 +30,8 @@ Because of slippage and the Mento price occasionally changing according to a pri
 [celo-exchange-bot](https://github.com/celo-org/celo-exchange-bot) is intended to be operated by the exchanger as it requires access to the source key, which must own CELO funds to exchange and is the account that performs the exchanges. Operating the bot requires some technical knowledge of dealing with keys and operating infrastructure. Currently, the bot requires the source key to be an HSM in Azure's Key Vault service. Information on how to use an Azure Cloud HSM can be found [here](/infra-partners/integration/cloud-hsm).
 
 See the repository's [README](https://github.com/celo-org/celo-exchange-bot) for information on building a Docker image and configurating the bot. Example infrastructure using Azure's [Container Instances](https://azure.microsoft.com/en-gb/services/container-instances/) is also provided in the repository [here](https://github.com/celo-org/celo-exchange-bot/tree/master/infrastructure-example). While the bot does require Azure Key Vault to be used for the source key and the provided example infrastructure is ran on Azure, the bot itself can be ran from anywhere as long as it's able to access its Azure Key Vault Cloud HSM.
+
+
+
+
+

--- a/home/manage/release-gold.mdx
+++ b/home/manage/release-gold.mdx
@@ -127,3 +127,9 @@ If the contract permits voting and validating using the unreleased balance, the 
 - Some grants are subject to “distribution schedules,” which control the release of funds outside of a traditional vesting schedule for legal reasons. This schedule is controlled by the `distributionRatio` and is adjustable by the `releaseOwner`.
 </Accordion>
 </AccordionGroup>
+
+
+
+
+
+

--- a/home/manage/self-custody.mdx
+++ b/home/manage/self-custody.mdx
@@ -434,3 +434,8 @@ celocli releasecelo:withdraw --contract $CELO_RG_ADDRESS --useLedger --value <CE
 ```
 
 To vote with any CELO in your beneficiary account, you'll want to register it as a Locked CELO Account, authorize a new vote signing key for it, then lock CELO.
+
+
+
+
+

--- a/home/protocol/celo-token.mdx
+++ b/home/protocol/celo-token.mdx
@@ -46,3 +46,8 @@ Regardless of the transfer method, CELO tokens **reflect in both the native acco
 ---
 
 By enabling seamless interoperability between native and ERC-20 transactions, **CELO remains highly flexible within the Ethereum and Celo ecosystems** without requiring additional conversion steps.
+
+
+
+
+

--- a/home/protocol/challengers.mdx
+++ b/home/protocol/challengers.mdx
@@ -17,3 +17,9 @@ Currently, there are six registered challengers. Five challengers are independen
 | [Grassroots Economics](https://sarafu.network/) | [`0xc6E6836CaCB6fF0a843050DB7F64bb2ab864C463`](https://eth.blockscout.com/address/0xc6E6836CaCB6fF0a843050DB7F64bb2ab864C463) |
 | [Swiftstaking](https://www.swiftstaking.com/) | [`0x53e8eeaae0731ccc888513695ec1bd792ec975ca`](https://eth.blockscout.com/address/0x53e8eeaae0731ccc888513695ec1bd792ec975ca) |
 | Usopp's | [`0x56966549e0953e8d6e17fcd3278b003d81f58ca8`](https://eth.blockscout.com/address/0x56966549e0953e8d6e17fcd3278b003d81f58ca8) |
+
+
+
+
+
+

--- a/home/protocol/epoch-rewards/carbon-offsetting-fund.mdx
+++ b/home/protocol/epoch-rewards/carbon-offsetting-fund.mdx
@@ -19,3 +19,8 @@ The Carbon Offsetting Fund represents Celo's commitment to environmental sustain
 
 - **Epoch rewards**: the Carbon Offsetting Fund receives 0.1% of epoch rewards, adjustable via governance and distributed automatically at each epoch.
 - **Transaction fees**: the Carbon Offsetting Fund receives 10% of transaction fees, adjustable via governance.
+
+
+
+
+

--- a/home/protocol/epoch-rewards/community-fund.mdx
+++ b/home/protocol/epoch-rewards/community-fund.mdx
@@ -33,3 +33,8 @@ All Community Fund activities are transparent and verifiable on-chain: [0xD533Ca
 For deeper analysis of Community Fund activities, use the [Dune Analytics dashboard](https://dune.com/superchain_eco/celo-community-treasury).
 
 For a detailed view of the fund's assets, including both historical and current spending breakdowns, explore the [Celo Community Fund website](https://www.celocommunityfund.xyz/).
+
+
+
+
+

--- a/home/protocol/epoch-rewards/index.mdx
+++ b/home/protocol/epoch-rewards/index.mdx
@@ -40,7 +40,7 @@ For technical changes since the L1 to L2 migration, refer to the [official specs
 ## Epoch Duration and Processing
 
 An epoch is a time period lasting at least one day, with no guaranteed maximum duration.
-The epoch logic is implemented in Solidity via the [EpochManager contract](/contracts/core-contracts), introduced in [Contract Release 12](https://github.com/celo-org/celo-monorepo/tree/core-contracts.v12).
+The epoch logic is implemented in Solidity via the [EpochManager contract](/tooling/contracts/core-contracts), introduced in [Contract Release 12](https://github.com/celo-org/celo-monorepo/tree/core-contracts.v12).
 
 Since epoch processing requires significant gas consumption, it's handled through multiple function calls rather than a single transaction.
 
@@ -96,3 +96,8 @@ After the initial phase, anyone can call `finishNextEpochProcess()` to complete 
    - Election: `EpochRewardsDistributedToVoters(address indexed group, uint256 value)`
    - CeloUnreleasedTreasury: `Released(address indexed to, uint256 amount)`
    - EpochManager: `EpochProcessingEnded(uint256 indexed epochNumber)`
+
+
+
+
+

--- a/home/protocol/escrow.mdx
+++ b/home/protocol/escrow.mdx
@@ -30,3 +30,8 @@ The recipient of an escrowed payment can choose to withdraw their payment assumi
 ## Revoking & Reclaiming
 
 Alice sends Bob an escrowed payment. Let's say Bob never withdraws it, or worse, the temporary private key he needs to withdraw the payment gets lost or sent to the wrong person. For this purpose, Celo's protocol also allows for senders to reclaim any unclaimed escrowed payment that they sent. After an escrowed payment's `expirySeconds` \(set by the sender on creation of the payment\) has passed, the sender of the payment can revoke the payment and reclaim their funds with just the paymentId.
+
+
+
+
+

--- a/home/protocol/governance/create-governance-proposal.mdx
+++ b/home/protocol/governance/create-governance-proposal.mdx
@@ -277,3 +277,9 @@ You will now need to add the addresses you are wishing to interact with
 ### Step 5: Create Transaction
 
 Click `Add Transaction`, and after that other multisig signers will need to confirm the transaction. Once the required number of signers have confirmed the transaction, it will be executed. You can also add a description to the transaction to help other signers understand the purpose of the transaction.
+
+
+
+
+
+

--- a/home/protocol/governance/governable-parameters.mdx
+++ b/home/protocol/governance/governable-parameters.mdx
@@ -28,3 +28,8 @@ List of governable parameters and governance restrictions on Celo.
 - How nodes sync
 - How nodes store their data locally
 - Most parameters that affect the blockchain
+
+
+
+
+

--- a/home/protocol/governance/governance-toolkit.mdx
+++ b/home/protocol/governance/governance-toolkit.mdx
@@ -37,3 +37,8 @@ The curent Celo Governance Guardians (formerly known as CGP Editors), actively p
   * Eric [Celo Forum](https://forum.celo.org/u/ericnakagawa), [Twitter](https://x.com/ericnakagawa)
   * Anna [Celo Forum](https://forum.celo.org/u/annaalexa), [Twitter](https://x.com/AnnaAlexaK)
   
+
+
+
+
+

--- a/home/protocol/governance/overview.mdx
+++ b/home/protocol/governance/overview.mdx
@@ -88,3 +88,9 @@ If a proposal is not accepted, a cool-off period is required for additional conv
 2. If a proposal is rejected and has a majority of NO votes, the proposal is moved back to the discussion stage and may be submitted for a vote after receiving approval from the Governance Guardians and waiting for 28 days.
 
 **Note**: In the event that a proposal meets or exceeds quorum, but is not approved in time, the proposers should be able to re-submit as soon as they are able. This would happen in rare situations when approvers are unable to approve during the 7-day Referendum phase or the 3-day Execution phase.
+
+
+
+
+
+

--- a/home/protocol/governance/smart-contracts-upgrades.mdx
+++ b/home/protocol/governance/smart-contracts-upgrades.mdx
@@ -24,3 +24,9 @@ The current process requires approval from both an approver multisig and the Sec
 ## Celo Blockchain Software Upgrades
 
 Some changes cannot be made through the onchain governance process alone. Examples include changes to the underlying consensus protocol and changes which would result in a hard-fork.
+
+
+
+
+
+

--- a/home/protocol/governance/voting-in-governance-using-mondo.mdx
+++ b/home/protocol/governance/voting-in-governance-using-mondo.mdx
@@ -36,3 +36,8 @@ To stay up-to-date with all governance activities and proposals:
 - Follow discussions on the [Celo Forum](https://forum.celo.org/) in the Governance category
 
 For more comprehensive information about Celo's governance system, see the [Governance Overview](/home/protocol/governance/overview) and [Voting in Governance](/home/protocol/governance/voting-in-governance) guides.
+
+
+
+
+

--- a/home/protocol/governance/voting-in-governance.mdx
+++ b/home/protocol/governance/voting-in-governance.mdx
@@ -180,3 +180,8 @@ To stay up-to-date with all governance activities and proposals:
 - Follow discussions on the [Celo Forum](https://forum.celo.org/) in the Governance category
 
 For more comprehensive information about Celo's governance system, see the [Governance Overview](/home/protocol/governance/overview) and [Voting in Governance](/home/protocol/governance/voting-in-governance) guides.
+
+
+
+
+

--- a/home/protocol/index.mdx
+++ b/home/protocol/index.mdx
@@ -32,3 +32,8 @@ There are a number of substantial changes and additions have been made in servic
 - [Stability Mechanism - Mento](https://www.mento.org/)
 - [Transactions](/legacy/protocol/transaction/index)
 - [Identity - Self](https://self.xyz/)
+
+
+
+
+

--- a/home/protocol/security-council.mdx
+++ b/home/protocol/security-council.mdx
@@ -53,3 +53,9 @@ For the most up-to-date information, refer to our [Celo L2 documentation](/build
 - **Security Standards**:
   - Follow Optimism multisig security policy.
   - Allow nested multisigs if all signers adhere to the security policy.
+
+
+
+
+
+

--- a/home/protocol/transactions/overview.mdx
+++ b/home/protocol/transactions/overview.mdx
@@ -28,7 +28,7 @@ gas currencies incur approximately 50,000 additional gas units.
 Celo allows paying gas fees in currencies other than the native currency. The tokens that can be
 used to pay gas fees are controlled via governance and the list of tokens allowed is maintained in
 FeeCurrencyDirectory.sol. Fee abstraction on Celo works with EOAs. No paymaster required! Learn all
-about [fee abstraction](/developer/fee-abstraction).
+about [fee abstraction](/tooling/overview/fee-abstraction).
 
 ## Transaction Fee Allocation Post-L2 Transition
 
@@ -51,3 +51,9 @@ This reallocation ensures that transaction fees are utilized effectively to main
 ## Conclusion
 
 Celo's transition to L2 introduces significant changes to gas pricing and transaction fee allocation, aligning with the network's goals of sustainability, user accessibility, and robust operational support. These adjustments are designed to enhance the overall efficiency and resilience of the Celo ecosystem.
+
+
+
+
+
+

--- a/home/protocol/transactions/transaction-types.mdx
+++ b/home/protocol/transactions/transaction-types.mdx
@@ -489,3 +489,9 @@ const walletClient = createWalletClient({
     </Tab>
 
 </Tabs>
+
+
+
+
+
+

--- a/home/protocol/transactions/tx-comment-encryption.mdx
+++ b/home/protocol/transactions/tx-comment-encryption.mdx
@@ -36,3 +36,8 @@ A 128 bit randomly generated session key, sk, is generated and used to symmetric
 5. The MAC key, km, is SHA-256 of the second 128 bits of k
 6. Encrypt the plaintext symmetrically with AES-128-CTR using ke, km, and a random iv
 7. Return ephemPubKey \| AES-128-CTR-HMAC\(ke, km, plaintext\) where the public key needs to be uncompressed \(current limitation with decrypt\).
+
+
+
+
+

--- a/home/ramps.mdx
+++ b/home/ramps.mdx
@@ -1012,3 +1012,8 @@ Below you'll find our complete network of 21+ integrated ramp providers, coverin
 - USDm
 
 ---
+
+
+
+
+

--- a/home/wallets.mdx
+++ b/home/wallets.mdx
@@ -11,7 +11,7 @@ Overview of digital wallets available to send, spend, and earn Celo assets.
 
 Celo is designed to work seamlessly with a range of wallets, each offering features to meet different user needs.
 
-The [Celo Native Wallets](#celo-native-wallets) section provides an overview of wallets that are optimized for the Celo network. These wallets allow users to fully benefit from Celo’s native functionalities, such as [phone number mapping](/legacy/protocol/identity) and [fee abstraction](/developer/fee-abstraction).
+The [Celo Native Wallets](#celo-native-wallets) section provides an overview of wallets that are optimized for the Celo network. These wallets allow users to fully benefit from Celo’s native functionalities, such as [phone number mapping](/legacy/protocol/identity) and [fee abstraction](/tooling/overview/fee-abstraction).
 
 The [Celo Compatible Wallets](#celo-compatible-wallets) section provides an overview of commonly used wallets wallets that support the Celo network.
 
@@ -146,3 +146,9 @@ Zerion Wallet is a non-custodial wallet for crypto that gives you access to a br
 
 - [Homepage](https://www.mtpelerin.com/bridge-wallet)
 - Platforms: iOS, Android
+
+
+
+
+
+

--- a/infra-partners/integration/checklist.mdx
+++ b/infra-partners/integration/checklist.mdx
@@ -35,7 +35,7 @@ Please read more under [Custody](/infra-partners/integration/custody), but here 
 
 Stable-value currencies, currently USDm and EURm, are contracts, `StableToken` and `StableTokenEUR` respectively, that can be accessed via the ERC20 interface. The native asset CELO can be accessed via the `GoldToken` ERC20 interface, or natively, similar to ETH on Ethereum.
 
-Addresses for those contracts can be found by querying the [registry](/developer/contractkit/contracts-wrappers-registry) or in the [Listing Guide](/infra-partners/integration/listings).
+Addresses for those contracts can be found by querying the [registry](/tooling/libraries-sdks/contractkit/contracts-wrappers-registry) or in the [Listing Guide](/infra-partners/integration/listings).
 
 ### Proof of Stake
 
@@ -84,3 +84,8 @@ Celo accounts can make claims to existing identities, some of which are verifiab
 ### Performance indicators
 
 Validator Groups and their validators can perform their duties differently and explorers should reflect that to allow voters to ensure an optimal validator set. While uptime in the form of block signatures by the validators ultimately affect rewards, explorers should also consider displaying [other metrics](/legacy/validator/voting) that impact the success of the Celo ecosystem, such as validators' performance in the identity protocol.
+
+
+
+
+

--- a/infra-partners/integration/cloud-hsm.mdx
+++ b/infra-partners/integration/cloud-hsm.mdx
@@ -121,3 +121,8 @@ const contractKit = newKitFromWeb3(this.web3, akvWallet);
 ## Summary
 
 You can now leverage a cloud HSM key to perform signing as a user or application. This improves both security and availability of your Celo keys. We also recommend enabling two-factor authentication across your Azure subscription and to leverage [Managed Service Identities](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) where possible.
+
+
+
+
+

--- a/infra-partners/integration/custody.mdx
+++ b/infra-partners/integration/custody.mdx
@@ -86,3 +86,8 @@ Some of these may occur as events rather than transactions on the network, and t
 ## Useful Tools
 
 Since monitoring balance changing operations is important to be able to display user balances properly, it can be helpful to use a tracing or reconciling system. [Celo Rosetta](https://github.com/celo-org/rosetta) is an RPC server that exposes an API to query the Celo blockchain, obtain balance changing operations, and construct airgapped transactions. With a special focus on getting balance change operations, Celo Rosetta provides an easy way to obtain changes that are not easily queryable using the celo-blockchain RPC.
+
+
+
+
+

--- a/infra-partners/integration/general.mdx
+++ b/infra-partners/integration/general.mdx
@@ -75,4 +75,9 @@ Compared to Ethereum transactions, Celo transactions have an additional optional
 To sign transactions, you have the following options:
 
 - Use the JSON-RPC [`sendTransaction`](https://github.com/ethereum/execution-apis/blob/c710097abda52b5a190d831eb8b1eddd3d28c603/tests/eth_sendRawTransaction/send-legacy-transaction.io) method to your node which would have the account in question unlocked. (Either manually or via a library such as `web3`)
-- Use [ContractKit's](/developer/contractkit/) local signing feature.
+- Use [ContractKit's](/tooling/libraries-sdks/contractkit/) local signing feature.
+
+
+
+
+

--- a/infra-partners/integration/index.mdx
+++ b/infra-partners/integration/index.mdx
@@ -24,3 +24,9 @@ Celo provides you with the tools to easily integrate DeFi into your existing mob
 - [Custody](/infra-partners/integration/custody)
 - [Listings](/infra-partners/integration/listings)
 - [Using a Cloud HSM](/infra-partners/integration/cloud-hsm)
+
+
+
+
+
+

--- a/infra-partners/integration/listings.mdx
+++ b/infra-partners/integration/listings.mdx
@@ -163,3 +163,8 @@ The Celo Protocol GitHub is located [here.](https://github.com/celo-org/)
 ### Audits
 
 All the security audits on the smart contracts, security and economics of the Celo Platform can be found [here](https://celo.org/audits).
+
+
+
+
+

--- a/infra-partners/notices/celo-sepolia-launch.mdx
+++ b/infra-partners/notices/celo-sepolia-launch.mdx
@@ -88,3 +88,9 @@ Thank you to the first wave of our ecosystem partners supporting Celo Sepolia al
 ## Getting Help
 
 Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+
+
+
+
+
+

--- a/infra-partners/notices/eigenda-v2-upgrade.mdx
+++ b/infra-partners/notices/eigenda-v2-upgrade.mdx
@@ -72,3 +72,9 @@ The new proxy version will require to *add* the following new flags for each net
 
 The required configuration for each service can be found in our [Docker Compose Setup](https://github.com/celo-org/celo-l2-node-docker-compose), where every network has a corresponding `<network>.env` file.
 </Tip>
+
+
+
+
+
+

--- a/infra-partners/notices/isthmus-upgrade.mdx
+++ b/infra-partners/notices/isthmus-upgrade.mdx
@@ -64,3 +64,9 @@ Make the following checks to verify that your node is properly configured.
 - op-node and op-geth will log their configurations at startup
 - Check that the Isthmus time is set to `activation-timestamp` in the `op-node` startup logs
 - Check that the Isthmus time is set to `activation-timestamp` in the `op-geth` startup logs
+
+
+
+
+
+

--- a/infra-partners/notices/jello-upgrade.mdx
+++ b/infra-partners/notices/jello-upgrade.mdx
@@ -38,3 +38,9 @@ We recommend the latest released versions:
 
 The required configuration for each service can be found in our [Docker Compose Setup](https://github.com/celo-org/celo-l2-node-docker-compose), where every network has a corresponding `<network>.env` file.
 </Tip>
+
+
+
+
+
+

--- a/infra-partners/notices/jovian-upgrade.mdx
+++ b/infra-partners/notices/jovian-upgrade.mdx
@@ -121,3 +121,9 @@ upgrade the event log index was maintained for all event logs since genesis, now
 the flag has a default setting of 28200000 blocks which is ~326 days. To index
 all event logs since genesis set the flag to zero.
 
+
+
+
+
+
+

--- a/infra-partners/notices/l1-fusaka-upgrade.mdx
+++ b/infra-partners/notices/l1-fusaka-upgrade.mdx
@@ -36,3 +36,9 @@ There are no upgrades required for the Celo L2 client for the L1 Fusaka upgrade.
 ## Getting Help
 
 Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+
+
+
+
+
+

--- a/infra-partners/notices/l2-migration.mdx
+++ b/infra-partners/notices/l2-migration.mdx
@@ -11,3 +11,9 @@ title: "Celo L2 Migration"
 The instructions for migrating a Celo node from Layer 1 to Layer 2 are outlined [in this guide](/infra-partners/operators/migrate-node). This process is necessary to transition your Celo L1 node to the new Celo L2 architecture based on the OP-Stack.
 
 If you wish to run a Celo L2 node from scratch, you can follow the instructions in the [Running a Celo Node](/infra-partners/operators/run-node) guide.
+
+
+
+
+
+

--- a/infra-partners/operators/architecture.mdx
+++ b/infra-partners/operators/architecture.mdx
@@ -17,3 +17,9 @@ The Execution Client is responsible for executing the block payloads it receives
 
 - To get your node up and running, start with the [operator guide](/infra-partners/operators/run-node).
 - If you've already got a Celo node up and running, check out [how to migrate it to a L2 node](/infra-partners/operators/migrate-node).
+
+
+
+
+
+

--- a/infra-partners/operators/migrate-node.mdx
+++ b/infra-partners/operators/migrate-node.mdx
@@ -272,3 +272,9 @@ If needed, you can also run the `check-db` script on its own as follows.
    ```
 
    This command takes in an optional `--fail-fast` flag that will make it exit at the first gap detected like it does when run via [celo-l2-node-docker-compose](https://github.com/celo-org/celo-l2-node-docker-compose). If the `--fail-fast` flag is not provided then the script will collect all the gaps it finds and print them out at the end.
+
+
+
+
+
+

--- a/infra-partners/operators/overview.mdx
+++ b/infra-partners/operators/overview.mdx
@@ -10,3 +10,9 @@ See the following document for more details:
 * [Celo L2 migration](/infra-partners/notices/l2-migration)
 
 See the guides for [running a node](/infra-partners/operators/run-node) or the guide on [how to migrate a L1 node](/infra-partners/operators/migrate-node).
+
+
+
+
+
+

--- a/infra-partners/operators/run-node.mdx
+++ b/infra-partners/operators/run-node.mdx
@@ -346,3 +346,9 @@ If you are hosting a public RPC node, please make sure the flag `--history.trans
 ## Getting Help
 
 Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+
+
+
+
+
+

--- a/infra-partners/specs.mdx
+++ b/infra-partners/specs.mdx
@@ -3,3 +3,8 @@ title: Celo L2 Specs
 url: https://specs.celo.org/
 sidebarTitle: Getting Started
 ---
+
+
+
+
+

--- a/legacy/faq.mdx
+++ b/legacy/faq.mdx
@@ -98,3 +98,9 @@ See [What's Changed Celo L1 -> L2](/legacy/transition/whats-changed/l1-l2) and [
 </Accordion>
 
 </AccordionGroup>
+
+
+
+
+
+

--- a/legacy/l1-architecture.mdx
+++ b/legacy/l1-architecture.mdx
@@ -67,3 +67,8 @@ The Celo Wallet application is a fully unmanaged wallet that allows users to sel
 - **Celo Wallet Blockchain API:** provides a GraphQL API to query transactions on the blockchain on a per-account basis, used to implement a user's activity feed.
 
 When end-users download the Celo Wallet from, for example, the Google Play Store, users are trusting both cLabs (or the entity that has made the application available in the Play Store) and Google to deliver a correct binary, and most users would feel that relying on these centralized services to provide this additional functionality is worthwhile.
+
+
+
+
+

--- a/legacy/node/run-mainnet.mdx
+++ b/legacy/node/run-mainnet.mdx
@@ -121,3 +121,8 @@ true
 $ celocli account:new
 ...
 ```
+
+
+
+
+

--- a/legacy/overview.mdx
+++ b/legacy/overview.mdx
@@ -34,3 +34,8 @@ The table below summarizes the technical changes involved in transitioning from 
 | **Finality**        | One block finality, instantaneous once block is produced.                                    | Finality depends on trust in sequencer, batcher, proposer, and eigenDA, or ultimately on Ethereum.            |
 
 For more detailed technical changes, see [Celo's L2 Migration Documentation](https://specs.celo.org/l2_migration.html).
+
+
+
+
+

--- a/legacy/protocol/consensus/index.mdx
+++ b/legacy/protocol/consensus/index.mdx
@@ -23,3 +23,8 @@ Blocks in IBFT protocol are final, which means that there are no forks and any v
 ## Validators
 
 Celo’s consensus protocol is performed by nodes that are selected as validators. There is a maximum cap on the number of active validators that can be changed by governance proposal, which is currently set at 110 validators. The active validator set is determined via the proof-of-stake process and is updated at the end of each epoch, a fixed period of approximately one day.
+
+
+
+
+

--- a/legacy/protocol/consensus/locating-nodes.mdx
+++ b/legacy/protocol/consensus/locating-nodes.mdx
@@ -34,3 +34,8 @@ The way that validators communicate their IP address to other validators is by p
 That message will contain `n` copies (where `n` is the total number of validators for the current epoch) of the sending validator's IP address where each copy is encrypted with the other validators' public key. Once a validator receives a gossiped _IstanbulAnnounce_ message, it will decrypt the encrypted IP address that was encrypted with its public key, and then establish a TCP connection to it. All consensus related messages will then sent via those direct TCP connections.
 
 When an epoch ends, a validator will establish new connections with any newly elected validator and disconnect from any removed validators. If the validator itself is removed from the new epoch's validator set, then it will disconnect with all the validators.
+
+
+
+
+

--- a/legacy/protocol/consensus/validator-set-differences.mdx
+++ b/legacy/protocol/consensus/validator-set-differences.mdx
@@ -14,3 +14,8 @@ This page describes the historical Celo Layer 1 blockchain. It is useful for und
 ## Computing Set Differences
 
 The validator set for a given epoch is elected at the end of the last block of the previous epoch. The new validator set is written to the **extradata** field of the header for this block. As an optimization, the validator set is encoded as the difference between the new and previous validator sets. Nodes that join the network are able to compute the validator set for the current epoch by starting with the initial validator set \(encoded in the genesis block\) and iteratively applying these diffs.
+
+
+
+
+

--- a/legacy/protocol/contracts/add-contract.mdx
+++ b/legacy/protocol/contracts/add-contract.mdx
@@ -26,3 +26,9 @@ The test directory is organized the same way as the contracts directory so feel 
 <Tip>
 Some build issues can be resolved by simply deleting the `build` and the `typechain` folder. Don’t forget to run `yarn build` once again.
 </Tip>
+
+
+
+
+
+

--- a/legacy/protocol/identity/encrypted-cloud-backup.mdx
+++ b/legacy/protocol/identity/encrypted-cloud-backup.mdx
@@ -111,3 +111,9 @@ Within 30 guesses, an attacker has a 5-9% chance of guessing a users first-choic
 In order to address this, it is highly recommended to block the most easily guessed PINs.
 One way to do this is to block PINs that are most popular.
 A suggested implementation, which is [implemented by the Valora wallet](https://github.com/valora-inc/wallet/blob/3940661c40d08e4c5db952bd0abeaabb0030fc7a/packages/mobile/src/pincode/authentication.ts#L56-L108), is to create a blocklist from the top 25k most frequently seen PINs in the HIBP Passwords dataset.
+
+
+
+
+
+

--- a/legacy/protocol/identity/index.mdx
+++ b/legacy/protocol/identity/index.mdx
@@ -52,3 +52,8 @@ The attestation service is a simple Node.js service that validators run to send 
 ### Future improvements to privacy
 
 Celo is committed to meet the privacy needs of its users. More details about areas for future research can be found in [Privacy Research](/legacy/protocol/identity/privacy-research)
+
+
+
+
+

--- a/legacy/protocol/identity/metadata.mdx
+++ b/legacy/protocol/identity/metadata.mdx
@@ -37,7 +37,7 @@ In the future ContractKit may support other types of claim, including:
 
 ## Handling Metadata
 
-You can interact with metadata files easily through the [CLI](/cli/account), or in your own scripts, tools or DApps via [ContractKit](/developer/contractkit/). Most commands require a node being available under `http://localhost:8545` to make view calls, and to modify metadata files, you'll need the relevant account to be unlocked to sign the files.
+You can interact with metadata files easily through the [CLI](/cli/account), or in your own scripts, tools or DApps via [ContractKit](/tooling/libraries-sdks/contractkit/). Most commands require a node being available under `http://localhost:8545` to make view calls, and to modify metadata files, you'll need the relevant account to be unlocked to sign the files.
 
 You can create an empty metadata file with:
 
@@ -68,3 +68,8 @@ Then, anyone can lookup your claims and verify them by running:
 ```bash
 celocli account:get-metadata $ACCOUNT_ADDRESS
 ```
+
+
+
+
+

--- a/legacy/protocol/identity/odis-domain-sequential-delay-domain.mdx
+++ b/legacy/protocol/identity/odis-domain-sequential-delay-domain.mdx
@@ -12,3 +12,9 @@ The motivating use case is allowing wallets to define how often users can attemp
 A full specification of the Sequential Delay Domain is available in an extension to CIP-40.
 
 - [Sequential Delay Domain Specification](https://github.com/celo-org/celo-proposals/blob/master/CIPs/CIP-0040/sequentialDelayDomain.md)
+
+
+
+
+
+

--- a/legacy/protocol/identity/odis-domain.mdx
+++ b/legacy/protocol/identity/odis-domain.mdx
@@ -48,3 +48,9 @@ When it is ready for review, contact a [CIP editor](https://github.com/celo-org/
 
 Implementing a new Domain type, which includes new rate limiting to be enforced by the ODIS operators, requires an upgrade to the ODIS server implementation.
 Once the new domain type is standardized, this implementation can be written and deployed to the staging and production ODIS service operators.
+
+
+
+
+
+

--- a/legacy/protocol/identity/odis-use-case-key-hardening.mdx
+++ b/legacy/protocol/identity/odis-use-case-key-hardening.mdx
@@ -40,3 +40,9 @@ In addition to using ODIS to harden passwords chosen by users, it is recommended
 Password filtering, blocking the user from setting a password which may be weak, can greatly improve the quality of a user's password and prevent it being broken by guessing the most common passwords (e.g. "password").
 [NIST 800-63](https://pages.nist.gov/800-63-3/sp800-63-3.html) recommends that passwords should be checked against a list of known compromised passwords, such as [HIBP Passwords](https://haveibeenpwned.com/Passwords).
 Additional research has found other [practical techniques for increasing the strength of passwords chosen by users](https://www.andrew.cmu.edu/user/nicolasc/publications/Tan-CCS20.pdf).
+
+
+
+
+
+

--- a/legacy/protocol/identity/odis-use-case-phone-number-privacy.mdx
+++ b/legacy/protocol/identity/odis-use-case-phone-number-privacy.mdx
@@ -38,3 +38,9 @@ Since blockchain accounts and phone numbers are not naturally Sybil-resistant (i
 
 The requirements for these factors are configured to make it prohibitively expensive to scrape large quantities of phone numbers while still allowing typical user flows to remain unaffected.
 In particular, it should be possible for a user to look up their contacts in order to send them payments.
+
+
+
+
+
+

--- a/legacy/protocol/identity/odis.mdx
+++ b/legacy/protocol/identity/odis.mdx
@@ -114,3 +114,9 @@ Both services leverage the [Celo Threshold BLS library](https://github.com/celo-
 The combiner and signers maintain some minimal state in a SQL database, mainly related to quota tracking.
 
 For storage of the BLS signing key, the signers currently support three cloud-based keystores: Azure Key Vault, AWS Secret Manager, and Google Secret Manager.
+
+
+
+
+
+

--- a/legacy/protocol/identity/privacy-research.mdx
+++ b/legacy/protocol/identity/privacy-research.mdx
@@ -14,3 +14,9 @@ One downside to this identity protocol is that knowledge of a phone number can l
 As with most public blockchains \(e.g. Bitcoin, Ethereum\), transactions and smart contracts calls on Celo are public for everyone to see. This means that if a user wants to map the hash of their phone number to their wallet address, people with knowledge of that user's phone number will be able to see their transactions and balances.
 
 To address this issue, the cLabs team, [Matterlabs](https://matterlabs.dev) and other esteemed zk-SNARK cryptographers and Celo community members are working to create a framework that makes it easy to create gas-efficient tokens that offer Zcash-like privacy, using a shared anonymity pool. Such an implementation could allow wallets to use the default identity mode easily without the risk that someone with your phone number could see your balance and transaction history.  */}
+
+
+
+
+
+

--- a/legacy/protocol/identity/smart-contract-accounts.mdx
+++ b/legacy/protocol/identity/smart-contract-accounts.mdx
@@ -60,7 +60,7 @@ To look up a wallet using a phone number:
 3. Use the on-chain identifier to get the account address
 4. Use the account address to get the wallet address (EOA)
 
-The first two steps are covered extensively in [this guide](/developer/contractkit/odis).
+The first two steps are covered extensively in [this guide](/tooling/libraries-sdks/contractkit/odis).
 
 To get the account address (step 3) you can use the [Attestation contract method `lookupAccountsForIdentifier`](https://github.com/celo-org/celo-monorepo/blob/e6fdaf798a662ffe2c12f9a74b28e0fa1c1f8101/packages/sdk/contractkit/src/wrappers/Attestations.ts#L472).
 
@@ -81,3 +81,9 @@ This data can't be signed by the `msg.sender` since it's originating from a cont
 ## Implementation
 
 The implementation of the meta-transaction wallet can be [found here](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/common/MetaTransactionWallet.sol).
+
+
+
+
+
+

--- a/legacy/protocol/pos/becoming-a-validator.mdx
+++ b/legacy/protocol/pos/becoming-a-validator.mdx
@@ -13,3 +13,9 @@ To participate in the network, an operator must put up a slashable commitment of
 Any account that meets the minimum stake and notice period requirements can register as a validator. By doing so, the locked funds on that account become ‘at risk’: a fraction of the stake can be slashed automatically for an evolving set of misbehaviors. In addition, the community can use governance proposals to slash funds, which avoids having to anticipate and encode in the protocol every possible misbehavior. As long as the CELO staked for a validator account is not slashed, it’s eligible to earn rewards like any other Locked Gold account.
 
 A validator joins a validator group by affiliating itself with it. However, to avoid untrusted or malicious validators joining a group, the validator group must accept the affiliation. Once done, the validator is added to the list of validators in the group. A validator can remove itself from a validator group at any time. Changes only take effect at the next subsequent election, so if the validator is currently participating in consensus, it’s expected to do so until the end of the epoch in which it deregisters itself.
+
+
+
+
+
+

--- a/legacy/protocol/pos/epoch-rewards-locked-gold.mdx
+++ b/legacy/protocol/pos/epoch-rewards-locked-gold.mdx
@@ -41,3 +41,8 @@ where $$rr$$ is the reward rate or voting yield, $$vf$$ is the voting fraction c
 Adjusting the on-target reward rate to account for under- or over-spending against the target schedule gives a baseline reward, essentially the percentage increase for a unit of Locked CELO voting for a group eligible for rewards.
 
 The reward for activated Locked CELO voting for a given group is determined as follows. First, if the group elected no validators in the current epoch, rewards are zero. Otherwise, the baseline reward rate factors in two deductions. It is multiplied by the slashing penalty for the group, and by the average epoch uptime score for validators in the group elected in the current epoch. Finally, the group's activated pool of Locked CELO is increased by this rate.
+
+
+
+
+

--- a/legacy/protocol/pos/epoch-rewards-validator.mdx
+++ b/legacy/protocol/pos/epoch-rewards-validator.mdx
@@ -65,3 +65,8 @@ When a validator is slashed, reduced rewards may lead other validators in the sa
 Validator groups are compensated by taking a share of the rewards allocated to validators. Validator groups set a **group share** rate when they register, and can change that at any time. The protocol automatically deducts this share, sending that portion of the epoch rewards to the validator group of which they were a member at the time of the last election.
 
 Since the sum of a validator’s reward and its validator group’s reward are the same regardless of the ‘group share’ that the group chooses, no side-channel collusion is possible to avoid deductions for downtime or previous slashing.
+
+
+
+
+

--- a/legacy/protocol/pos/epoch-rewards.mdx
+++ b/legacy/protocol/pos/epoch-rewards.mdx
@@ -48,3 +48,8 @@ There is a target schedule for the release of CELO epoch rewards. The proposed t
 The total **actual rewards** paid out at the end of a given epoch result from multiplying the total on-target rewards with a `Rewards Multiplier`. This adjustment factor is a function of the percentage deviation of the remaining epoch rewards from the target epoch rewards remaining. It evaluates to `1` if the remaining epoch rewards are at the target and to smaller \(or larger\) than `1` if the remaining rewards are below \(or above, respectively\) the target. This creates a drag towards the target schedule.
 
 The sensitivity of the adjustment factor to the percentage deviation from the target are governable parameters: one for an underspend, one for an overspend.
+
+
+
+
+

--- a/legacy/protocol/pos/index.mdx
+++ b/legacy/protocol/pos/index.mdx
@@ -63,3 +63,8 @@ In Celo blockchain:
 - [`consensus/istanbul/backend/backend.go`](https://github.com/celo-org/celo-blockchain/blob/master/consensus/istanbul/backend/backend.go) performs validator elections in the last block of the epoch and calculates the new [validator set diff](/legacy/protocol/consensus/validator-set-differences).
 
 - [`consensus/istanbul/backend/pos.go`](https://github.com/celo-org/celo-blockchain/blob/master/consensus/istanbul/backend/pos.go) is called in the last block of the epoch to process validator uptime scores and make epoch rewards.
+
+
+
+
+

--- a/legacy/protocol/pos/locked-gold.mdx
+++ b/legacy/protocol/pos/locked-gold.mdx
@@ -73,3 +73,8 @@ The governance participants who cannot actively participate to vote on governanc
 Currently, participants can only delegate to 10 other delegatees.
 
 Participants can follow the steps [here](/home/protocol/governance/voting-in-governance#vote-delegation) to perform delegation using CeloCLI.
+
+
+
+
+

--- a/legacy/protocol/pos/penalties.mdx
+++ b/legacy/protocol/pos/penalties.mdx
@@ -46,3 +46,8 @@ In exchange for sending a transaction which initiates a successful provable slas
 ### **Governed**
 
 For misbehavior which is harder to formally classify and requires some off-chain knowledge, slashing can be performed via [governance proposals](/home/protocol/governance/overview). These conditions are important for preventing nuanced validator attacks.
+
+
+
+
+

--- a/legacy/protocol/pos/validator-elections.mdx
+++ b/legacy/protocol/pos/validator-elections.mdx
@@ -57,3 +57,8 @@ Then, in the first iteration, the algorithm assigns the first seat to the group 
 ### Number of Active Validators
 
 There is a minimum target and a maximum cap on the number of active validators that may be selected. If the minimum target is not reached, the election aborts and no change is made to the validator set this epoch.
+
+
+
+
+

--- a/legacy/protocol/pos/validator-groups.mdx
+++ b/legacy/protocol/pos/validator-groups.mdx
@@ -65,3 +65,8 @@ Both validators and validator groups can use [Accounts Metadata](/legacy/protoco
 ## Dissolving of a Validator Group
 
 There is a 180 day unlocking period for Celo locked when creating a validator group.
+
+
+
+
+

--- a/legacy/protocol/randomness.mdx
+++ b/legacy/protocol/randomness.mdx
@@ -53,3 +53,8 @@ contract Example is UsingRegistryV2 {
     }
 }
 ```
+
+
+
+
+

--- a/legacy/protocol/stability/adding-stable-assets.mdx
+++ b/legacy/protocol/stability/adding-stable-assets.mdx
@@ -87,3 +87,8 @@ Adding a new stable asset involves updating many parts of the tooling, such as:
 <Info>
 [^2] Please note this example proposal also includes freezing, this is because, at the time of writing (22-march-2021), the tooling for proposing a contract release doesn't support freezing those contracts on the same proposal. Proposals shall not be modified manually given that the tool is meant to run verifications.
 </Info>
+
+
+
+
+

--- a/legacy/protocol/stability/doto.mdx
+++ b/legacy/protocol/stability/doto.mdx
@@ -58,3 +58,8 @@ For a more detailed explanation, read the article [Zooming in on the Celo Expans
 ## Multi-mento Deployment
 
 Many instances of mento can be deployed in parallel for different stable assets. Currently, `cEUR` and `cUSD` live side-by-side, with independent buckets and oracle reports (although both of them are using the same `SortedOracles` instance). They all fill the CELO bucket with funds from the Reserve, but not necessarily at the same time.
+
+
+
+
+

--- a/legacy/protocol/stability/granda-mento.mdx
+++ b/legacy/protocol/stability/granda-mento.mdx
@@ -54,3 +54,8 @@ The approver multi-sig that is ultimately responsible for approving an exchange 
 | Zviad Metreveli | WOTrust                       | `zm #1073`                | `0xE267D978037B89db06C6a5FcF82fAd8297E290ff` |
 | human           | OpenCelo                      | `human #6811`             | `0x91f2437f5C8e7A3879e14a75a7C5b4CccC76023a` |
 | Deepak Nuli     | Kresko                        | `Deepak \| Kresko#3647`   | `0x099f3F5527671594351E30B48ca822cc90778a11` |
+
+
+
+
+

--- a/legacy/protocol/stability/index.mdx
+++ b/legacy/protocol/stability/index.mdx
@@ -34,3 +34,8 @@ The Celo protocol's stability mechanism comprises the following:
 - [Oracles](/legacy/protocol/stability/oracles)
 - [Stability Fees](/legacy/protocol/stability/stability-fees)
 - [Adding Stable Tokens](/legacy/protocol/stability/adding-stable-assets)
+
+
+
+
+

--- a/legacy/protocol/stability/oracles.mdx
+++ b/legacy/protocol/stability/oracles.mdx
@@ -29,3 +29,8 @@ To ensure the oracle's value doesn't go stale due to inactive reporters, any rep
 ## Celo-Oracle Repository
 
 You can find more information about the technical specification of the Celo Oracles feeding data to the reserve in the [GitHub repository here](https://github.com/celo-org/celo-oracle).
+
+
+
+
+

--- a/legacy/protocol/stability/stability-fees.mdx
+++ b/legacy/protocol/stability/stability-fees.mdx
@@ -61,3 +61,8 @@ The `updateInflationFactor` modifier is called by the following functions:
 - `transferFrom`
 - `transfer`
 - `debitFrom`
+
+
+
+
+

--- a/legacy/protocol/transaction/erc20-transaction-fees.mdx
+++ b/legacy/protocol/transaction/erc20-transaction-fees.mdx
@@ -19,7 +19,7 @@ The protocol maintains a governable allowlist of smart contract addresses which 
 
 ## Allowlisted Gas Fee Addresses
 
-To obtain a list of the gas fee addresses that have been allowlisted using [Celo's Governance Process](/home/protocol/governance/overview), you can run the `getCurrencies` method on the `FeeCurrencyDirectory` contract. All other notable Mainnet core smart contracts are listed [here](/contracts/core-contracts#celo-mainnet).
+To obtain a list of the gas fee addresses that have been allowlisted using [Celo's Governance Process](/home/protocol/governance/overview), you can run the `getCurrencies` method on the `FeeCurrencyDirectory` contract. All other notable Mainnet core smart contracts are listed [here](/tooling/contracts/core-contracts#celo-mainnet).
 
 ### Tokens with Adapters
 
@@ -81,3 +81,8 @@ let tx = {
 <Note>
 To get details about the underlying token of the adapter you can call `adaptedToken` function on the adapter address, which will return the underlying token address.
 </Note>
+
+
+
+
+

--- a/legacy/protocol/transaction/escrow.mdx
+++ b/legacy/protocol/transaction/escrow.mdx
@@ -30,3 +30,8 @@ The recipient of an escrowed payment can choose to withdraw their payment assumi
 ## Revoking & Reclaiming
 
 Alice sends Bob an escrowed payment. Let’s say Bob never withdraws it, or worse, the temporary private key he needs to withdraw the payment gets lost or sent to the wrong person. For this purpose, Celo’s protocol also allows for senders to reclaim any unclaimed escrowed payment that they sent. After an escrowed payment's `expirySeconds` \(set by the sender on creation of the payment\) has passed, the sender of the payment can revoke the payment and reclaim their funds with just the paymentId.
+
+
+
+
+

--- a/legacy/protocol/transaction/gas-pricing.mdx
+++ b/legacy/protocol/transaction/gas-pricing.mdx
@@ -40,3 +40,8 @@ When the client wants to ensure that their transaction is processed quickly, the
 ## Transaction Fee Recipients
 
 The required portion of gas fee, known as the **base**, is set as `base = gas_price_minimum * gas_used` and is sent to the Gas Fee Handler smart contract, which is controlled by governance and handles how the fees are used (e.g., for carbon removal and burning). The rest of the gas fee, known as the **tip**, is rewarded to the validator that proposes the block. Block producers only receive the tip and not the base of the gas fee, which means that they do not have an incentive to artificially inflate the gas price minimum by flooding the network with transactions.
+
+
+
+
+

--- a/legacy/protocol/transaction/index.mdx
+++ b/legacy/protocol/transaction/index.mdx
@@ -21,3 +21,8 @@ Transactions in the Celo protocol include payments, contract calls, and other op
 
 - Gas prices must meet or exceed the [gas price minimum](/legacy/protocol/transaction/gas-pricing).
 - Gas fees may be paid in currencies other than the native CELO.
+
+
+
+
+

--- a/legacy/protocol/transaction/native-currency.mdx
+++ b/legacy/protocol/transaction/native-currency.mdx
@@ -24,3 +24,8 @@ The native currency in the Celo protocol, CELO, conforms to the ERC20 interface.
 
 As the native currency of the protocol, CELO, much like Ether, can still be sent directly via transactions by specifying a non-zero “value”, bypassing the ERC20 interface.
 </Tip>
+
+
+
+
+

--- a/legacy/protocol/transaction/transaction-types.mdx
+++ b/legacy/protocol/transaction/transaction-types.mdx
@@ -469,3 +469,9 @@ const walletClient = createWalletClient({
     </Tab>
 
 </Tabs>
+
+
+
+
+
+

--- a/legacy/protocol/transaction/tx-comment-encryption.mdx
+++ b/legacy/protocol/transaction/tx-comment-encryption.mdx
@@ -43,3 +43,8 @@ A 128 bit randomly generated session key, sk, is generated and used to symmetric
 5.  The MAC key, km, is SHA-256 of the second 128 bits of k
 6.  Encrypt the plaintext symmetrically with AES-128-CTR using ke, km, and a random iv
 7.  Return ephemPubKey \| AES-128-CTR-HMAC\(ke, km, plaintext\) where the public key needs to be uncompressed \(current limitation with decrypt\).
+
+
+
+
+

--- a/legacy/transition/guides/bridging-celo-from-l1-to-l2.mdx
+++ b/legacy/transition/guides/bridging-celo-from-l1-to-l2.mdx
@@ -141,3 +141,9 @@ The following example demonstrates how to configure a file with all the details 
     main();
     ```
 </CodeGroup>
+
+
+
+
+
+

--- a/legacy/transition/guides/withdrawing-celo-from-l2-to-l1.mdx
+++ b/legacy/transition/guides/withdrawing-celo-from-l2-to-l1.mdx
@@ -142,3 +142,9 @@ The following example demonstrates how to configure a file with all the details 
     ```
 
 </CodeGroup>
+
+
+
+
+
+

--- a/legacy/transition/optimism/op-l2.mdx
+++ b/legacy/transition/optimism/op-l2.mdx
@@ -44,3 +44,9 @@ The hardcoded protocol parameter `MaxCodeSize` is raised from 24576 to 65536.
 ## Improved finality guarantees
 
 Celo L2 blocks reference L1 blocks that are finalized, which fully protects against L1 re-orgs. In contrast, Optimism blocks reference only 4 blocks behind the L1 head.
+
+
+
+
+
+

--- a/legacy/transition/whats-changed/l1-l2.mdx
+++ b/legacy/transition/whats-changed/l1-l2.mdx
@@ -99,3 +99,9 @@ Just give it the path to your keystore and the name of your key, e.g.
 Enter password:
 testkey's private key is: 0x2089e0db913b30b1c4084f3bd32ca3fd53e28437d76dbd0e609b0884b2c540ef
 ```
+
+
+
+
+
+

--- a/legacy/transition/whats-changed/overview.mdx
+++ b/legacy/transition/whats-changed/overview.mdx
@@ -9,3 +9,9 @@ Celo is moving from being a POS (proof of stake) based L1 blockchain to an L2 bu
 
 * [Celo L1 → L2 changes](/legacy/transition/whats-changed/l1-l2)
 * [Optimism → Celo L2 changes](/legacy/transition/optimism/op-l2)
+
+
+
+
+
+

--- a/legacy/validator/celo-foundation-voting-policy.mdx
+++ b/legacy/validator/celo-foundation-voting-policy.mdx
@@ -160,3 +160,9 @@ If you would like to keep up-to-date with all the news happening in the Celo com
 
 You can add the [Celo Signal public calendar](https://calendar.google.com/calendar/u/0/embed?src=c_9su6ich1uhmetr4ob3sij6kaqs@group.calendar.google.com) as well which has relevant dates.
 </Note>
+
+
+
+
+
+

--- a/legacy/validator/celo-website.mdx
+++ b/legacy/validator/celo-website.mdx
@@ -2,3 +2,8 @@
 title: Celo Website
 url: https://celo.org
 ---
+
+
+
+
+

--- a/legacy/validator/devops-best-practices.mdx
+++ b/legacy/validator/devops-best-practices.mdx
@@ -33,3 +33,8 @@ That way, in the event of a node or instance failure on your validator box, whic
 ### Kubernetes
 
 We are working on getting a Kubernetes recommended specification and will update this section once we have a recommended spec. If you are using Kubernetes with your validator node, feel free to submit a PR to update this section with your setup.
+
+
+
+
+

--- a/legacy/validator/discord.mdx
+++ b/legacy/validator/discord.mdx
@@ -2,3 +2,8 @@
 title: Celo Discord
 url: https://discord.com/invite/celo
 ---
+
+
+
+
+

--- a/legacy/validator/index.mdx
+++ b/legacy/validator/index.mdx
@@ -41,3 +41,9 @@ Not ready to become a Celo Validator? [Learn more about Celo](/).
 <Tip>
 For questions, comments, and discussions please use the [Celo Forum](https://forum.celo.org/) or [Discord](https://chat.celo.org/).
 </Tip>
+
+
+
+
+
+

--- a/legacy/validator/key-management/detailed.mdx
+++ b/legacy/validator/key-management/detailed.mdx
@@ -160,3 +160,8 @@ celocli account:show $LOCKED_GOLD_ACCOUNT
 # You can also look up account info via the authorized signer
 celocli account:show $SIGNER_TO_AUTHORIZE
 ```
+
+
+
+
+

--- a/legacy/validator/key-management/key-rotation.mdx
+++ b/legacy/validator/key-management/key-rotation.mdx
@@ -68,3 +68,8 @@ The newly authorized keys will only take effect in the next epoch, so the instan
 </Warning>
 
 5. Shut down the validator instance with the now obsolete signer key.
+
+
+
+
+

--- a/legacy/validator/key-management/summary.mdx
+++ b/legacy/validator/key-management/summary.mdx
@@ -35,3 +35,8 @@ For more details on a specific key type, please see the more detailed sections b
 <Warning>
 A Locked CELO Account may have at most one authorized signer of each type at any time. Once a signer is authorized, the only way to deauthorize that signer is to authorize a new signer that has never previously been used as an authorized signer or Locked CELO Account. It follows then that a newly deauthorized signer cannot be reauthorized.
 </Warning>
+
+
+
+
+

--- a/legacy/validator/monitoring.mdx
+++ b/legacy/validator/monitoring.mdx
@@ -154,3 +154,8 @@ Celo adds specific functions around consensus:
 Prometheus exporter that scrapes downtime and meta information for a specified validator signer address from the Celo blockchain. All data is collected from a blockchain node via RPC.
 
 {/* ## Monitoring Network Health, Elections, and Accounts */}
+
+
+
+
+

--- a/legacy/validator/node-upgrade.mdx
+++ b/legacy/validator/node-upgrade.mdx
@@ -167,3 +167,8 @@ Release 1.2.0 is backwards incompatible in the Validator and Proxy connection. V
 </Danger>
 
 With multi-proxy, you can upgrade proxies one by one or can add newly synced proxies with the latest Docker image and can remove the old proxies. If upgrading the proxies in place, a rolling upgrade is recommended as the validator will re-assign direct connections as proxies are added and removed. These re-assignments will allow the validator to continue to participate in consensus.
+
+
+
+
+

--- a/legacy/validator/proxy.mdx
+++ b/legacy/validator/proxy.mdx
@@ -32,3 +32,8 @@ There are two ways to specify the proxy information to a validator. It can be do
 - `istanbul.proxies` can be used on the validator to list the validator's proxy set
 
 - `istanbul.proxiedValidators` can be used on the proxies to list the proxied validators
+
+
+
+
+

--- a/legacy/validator/run/mainnet.mdx
+++ b/legacy/validator/run/mainnet.mdx
@@ -23,3 +23,8 @@ While other Validator Groups will exist on the Celo Network, the fastest way to 
 Because of the importance of Validator security and availability, Validators are expected to run a "proxy" node in front of each Validator node. In this setup, the Proxy node connects with the rest of the network, and the Validator node communicates only with the Proxy, ideally via a private network.
 
 [Read more about Celo's mission and why you may want to become a Validator.](https://medium.com/celoorg/calling-all-chefs-become-a-celo-validator-c75d1c2909aa) - This article still uses the term Celo Gold which is the deprecated name for the Celo native asset, which now is referred to simply as "Celo" or preferably "CELO".
+
+
+
+
+

--- a/legacy/validator/security.mdx
+++ b/legacy/validator/security.mdx
@@ -30,3 +30,8 @@ Beyond the RPC interface, Celo nodes and services have other interfaces that act
 
 - **DDoS protection:** Protected public endpoints from a DDoS attack is highly recommended to allow valid requests to be served
 - **Whitelist endpoints:** The attestation service exposes a limited number of paths to function correctly. You could use a reverse proxy to reject paths that don't match them.
+
+
+
+
+

--- a/legacy/validator/troubleshooting-faq.mdx
+++ b/legacy/validator/troubleshooting-faq.mdx
@@ -57,3 +57,8 @@ You can then run celocli and point it to your local geth.ipc file:
 # Check if node is synced using celocli
 sudo celocli node:synced --node geth.ipc
 ```
+
+
+
+
+

--- a/legacy/validator/validator-explorer.mdx
+++ b/legacy/validator/validator-explorer.mdx
@@ -107,3 +107,8 @@ celocli account:get-metadata $CELO_VALIDATOR_GROUP_RG_ADDRESS
 ```
 
 If everything went well, you should now have your group and validator associated with each other and with your associated domain!
+
+
+
+
+

--- a/legacy/validator/voting.mdx
+++ b/legacy/validator/voting.mdx
@@ -94,3 +94,8 @@ The estimate is calculated based on past performance.
 
 Vido is a block visualization and monitoring suite for Mainnet and the Baklava testnet.
 It shows missed blocks and downtime for the Validator group set and subscribable metrics to get alerted if your Validator is no longer signing.
+
+
+
+
+

--- a/legacy/whitepapers.mdx
+++ b/legacy/whitepapers.mdx
@@ -2,3 +2,8 @@
 title: Whitepapers
 url: https://celo.org/papers
 ---
+
+
+
+
+

--- a/snippets/InlineImage.mdx
+++ b/snippets/InlineImage.mdx
@@ -13,3 +13,8 @@ export const InlineImage = ({ src, alt = '', height = '1.6em' }) => {
     />
   );
 };
+
+
+
+
+

--- a/snippets/schema.mdx
+++ b/snippets/schema.mdx
@@ -5,3 +5,8 @@ export const QueryArgsTable = ({ queryName }) => {
     </div>
   );
 };
+
+
+
+
+

--- a/snippets/tokens.mdx
+++ b/snippets/tokens.mdx
@@ -22,3 +22,9 @@
 | WLD | Worldcoin | L1: [0x163f8C2467924be0ae7B5347228CABF260318753](https://etherscan.io/token/0x163f8C2467924be0ae7B5347228CABF260318753)<br />L2: [0x88c400d871829e381b53b55eee79145b4287461a](https://celoscan.io/token/0x88c400d871829e381b53b55eee79145b4287461a) |
 | WBTC | Wrapped BTC | L1: [0x2260fac5e5542a773aa44fbcfedf7c193bc2c599](https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599)<br />L2: [0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D](https://celoscan.io/token/0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D) |
 | WETH | Wrapped Ether | L1: [0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2)<br />L2: [0xD221812de1BD094f35587EE8E174B07B6167D9Af](https://celoscan.io/token/0xD221812de1BD094f35587EE8E174B07B6167D9Af) |
+
+
+
+
+
+

--- a/tooling/bridges/bridges.mdx
+++ b/tooling/bridges/bridges.mdx
@@ -146,3 +146,9 @@ https://galaxy.exchange/swap
 <Card href="https://smolrefuel.com/?outboundChain=42220" arrow title="SmolRefuel">
 https://smolrefuel.com/?outboundChain=42220
 </Card>
+
+
+
+
+
+

--- a/tooling/bridges/cross-chain-messaging.mdx
+++ b/tooling/bridges/cross-chain-messaging.mdx
@@ -91,3 +91,9 @@ https://layerzero.network/
 <Card href="https://axelar.network/" title="">
 https://axelar.network/
 </Card>
+
+
+
+
+
+

--- a/tooling/contract-verification/blockscout.mdx
+++ b/tooling/contract-verification/blockscout.mdx
@@ -7,3 +7,8 @@ og:description: How to verify a Smart Contract on Celo using Blockscout
 Verifying a smart contract allows developers to review your code from within the [Celo Blockscout instance](https://celo.blockscout.com).
 
 * For detailed instructions follow the official documentation from [docs.blockscout.com](https://docs.blockscout.com/devs/verification)
+
+
+
+
+

--- a/tooling/contract-verification/celoscan.mdx
+++ b/tooling/contract-verification/celoscan.mdx
@@ -31,3 +31,8 @@ Verifying a smart contract allows developers to review your code from within the
 <Frame>
 ![github](/img/doc-images/verify-celoscan/image4.png)
 </Frame>
+
+
+
+
+

--- a/tooling/contract-verification/foundry.mdx
+++ b/tooling/contract-verification/foundry.mdx
@@ -8,7 +8,7 @@ Verifying a smart contract allows developers to review your code from within the
 
 ## Prerequisites
 
-[Project must be setup using Foundry](/developer/deploy/foundry)
+[Project must be setup using Foundry](/tooling/dev-environments/foundry)
 
 
 ## Verifying Contracts
@@ -34,3 +34,9 @@ For Celo Mainnet:
 forge verify-contract --chain-id 42220 <contract_address> <contract_location> --etherscan-api-key $ETHERSCAN_API_KEY
  --watch
 ```
+
+
+
+
+
+

--- a/tooling/contract-verification/hardhat.mdx
+++ b/tooling/contract-verification/hardhat.mdx
@@ -91,3 +91,8 @@ Celo Mainnet
 ```bash
 npx hardhat verify [CONTRACT_ADDRESS] [CONSTRUCTOR_ARGS] --network celo
 ```
+
+
+
+
+

--- a/tooling/contract-verification/index.mdx
+++ b/tooling/contract-verification/index.mdx
@@ -10,11 +10,17 @@ How to verify contracts deployed on Celo.
 
 ---
 
-The fastest way to verify on Celo is to use [hardhat-celo](/developer/verify/hardhat). Alternatively, you can use the Celo Explorer and CeloScan to verify contracts using a user interface.
+The fastest way to verify on Celo is to use [hardhat-celo](/tooling/contract-verification/hardhat). Alternatively, you can use the Celo Explorer and CeloScan to verify contracts using a user interface.
 
 ## Verify Contracts on Celo
 
-- [Using Blockscout](/developer/verify/blockscout)
-- [Using Remix](/developer/verify/remix)
-- [Using CeloScan](/developer/verify/celoscan)
-- [Using Hardhat](/developer/verify/hardhat)
+- [Using Blockscout](/tooling/contract-verification/blockscout)
+- [Using Remix](/tooling/contract-verification/remix)
+- [Using CeloScan](/tooling/contract-verification/celoscan)
+- [Using Hardhat](/tooling/contract-verification/hardhat)
+
+
+
+
+
+

--- a/tooling/contract-verification/remix.mdx
+++ b/tooling/contract-verification/remix.mdx
@@ -19,3 +19,8 @@ The source code of the contract that you are verifying will need to be in Remix.
 </Frame>
 
 - Navigate to the **Contract Address Details Page** in the block explore to, use the **Code, Read Contract**, and **Write Contract** panels to view and interact with your deployed smart contract.
+
+
+
+
+

--- a/tooling/contracts/core-contracts.mdx
+++ b/tooling/contracts/core-contracts.mdx
@@ -74,3 +74,8 @@ Core contract addresses for the Celo networks.
 | StableTokenEUR | [`0x6B172e333e2978484261D7eCC3DE491E79764BbC`](https://celo-sepolia.blockscout.com/address/0x6B172e333e2978484261D7eCC3DE491E79764BbC) |
 | UniswapFeeHandlerSeller | [`0x82f08A9f4993CBa538D95A3d58d58C070145eC87`](https://celo-sepolia.blockscout.com/address/0x82f08A9f4993CBa538D95A3d58d58C070145eC87) |
 | Validators | [`0x5E7b295bd8D80625e2cCac97C98123aaEB5E7Ea5`](https://celo-sepolia.blockscout.com/address/0x5E7b295bd8D80625e2cCac97C98123aaEB5E7Ea5) |
+
+
+
+
+

--- a/tooling/contracts/l1-contracts.mdx
+++ b/tooling/contracts/l1-contracts.mdx
@@ -81,3 +81,8 @@ L1 contract addresses for the Celo networks.
 | SystemConfigProxy | [`0x760a5f022c9940f4a074e0030be682f560d29818`](https://eth-sepolia.blockscout.com/address/0x760a5f022c9940f4a074e0030be682f560d29818) |
 | SystemConfigImpl | [`0x1edd39f1662fa3f3c4003b013e899c2cff976377`](https://eth-sepolia.blockscout.com/address/0x1edd39f1662fa3f3c4003b013e899c2cff976377) |
 | SystemOwnerSafe | [`0x5e60d897Cd62588291656b54655e98ee73f0aabF`](https://eth-sepolia.blockscout.com/address/0x5e60d897Cd62588291656b54655e98ee73f0aabF) |
+
+
+
+
+

--- a/tooling/contracts/token-contracts.mdx
+++ b/tooling/contracts/token-contracts.mdx
@@ -66,3 +66,8 @@ celocli network:whitelist
 | Wrapped Ether (Celo native bridge) | WETH | [`0x2cE73DC897A3E10b3FF3F86470847c36ddB735cf`](https://celo-sepolia.blockscout.com/address/0x2cE73DC897A3E10b3FF3F86470847c36ddB735cf) |
 | Mento West African CFA franc | XOFm | [`0x5505b70207aE3B826c1A7607F19F3Bf73444A082`](https://celo-sepolia.blockscout.com/address/0x5505b70207aE3B826c1A7607F19F3Bf73444A082) |
 | Mento South African Rand | ZARm | [`0x10CCfB235b0E1Ed394bACE4560C3ed016697687e`](https://celo-sepolia.blockscout.com/address/0x10CCfB235b0E1Ed394bACE4560C3ed016697687e) |
+
+
+
+
+

--- a/tooling/contracts/uniswap-contracts.mdx
+++ b/tooling/contracts/uniswap-contracts.mdx
@@ -39,3 +39,9 @@ Uniswap v4 introduces a new modular architecture with hooks and singleton pool m
 | Permit2                            | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://celoscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://alfajores.celoscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
 | UniversalRouter                    | [0x643770E279d5D0733F21d6DC03A8efbABf3255B4](https://celoscan.io/address/0x643770E279d5D0733F21d6DC03A8efbABf3255B4) | [0x84904B9E85F76a421223565be7b596d7d9A8b8Ce](https://alfajores.celoscan.io/address/0x84904B9E85F76a421223565be7b596d7d9A8b8Ce) |
 | v3StakerAddress                    | [0x6586FB35393abF7Ff454977a9b3c912d218791C6](https://celoscan.io/address/0x6586FB35393abF7Ff454977a9b3c912d218791C6) | [0x8AC47D3e65a3e6aD14596ee7d18ad1d1aA53208F](https://alfajores.celoscan.io/address/0x8AC47D3e65a3e6aD14596ee7d18ad1d1aA53208F) |
+
+
+
+
+
+

--- a/tooling/dev-environments/foundry.mdx
+++ b/tooling/dev-environments/foundry.mdx
@@ -109,7 +109,7 @@ forge create --rpc-url celo-sepolia --private-key <your_private_key> src/Counter
 <Note>
 Notice the contract name after `:`, this is because a single solidity file can have multiple contracts.
 
-It is recommended to use `--verify` flag so that the contract gets verified right after deployment, this requires [etherscan configuration](/developer/verify/foundry) in the `foundry.toml` file.
+It is recommended to use `--verify` flag so that the contract gets verified right after deployment, this requires [etherscan configuration](/tooling/contract-verification/foundry) in the `foundry.toml` file.
 </Note>
 
 On successful deployment, you should a following output!
@@ -117,3 +117,9 @@ On successful deployment, you should a following output!
 <Frame>
 ![github](/img/doc-images/deploy-foundry/image1.png)
 </Frame>
+
+
+
+
+
+

--- a/tooling/dev-environments/hardhat.mdx
+++ b/tooling/dev-environments/hardhat.mdx
@@ -96,7 +96,13 @@ Learn more about building and deploying dApps using the <a href="https://hardhat
 
 ## Verify Contracts on Celo
 
-- [Using Blockscout](/developer/verify/blockscout)
-- [Using Remix](/developer/verify/remix)
-- [Using CeloScan](/developer/verify/celoscan)
-- [Using Hardhat](/developer/verify/hardhat)
+- [Using Blockscout](/tooling/contract-verification/blockscout)
+- [Using Remix](/tooling/contract-verification/remix)
+- [Using CeloScan](/tooling/contract-verification/celoscan)
+- [Using Hardhat](/tooling/contract-verification/hardhat)
+
+
+
+
+
+

--- a/tooling/dev-environments/index.mdx
+++ b/tooling/dev-environments/index.mdx
@@ -30,6 +30,12 @@ Learn more about Celo Composer in the [README](https://github.com/celo-org/celo-
 Developers can build with Celo using many [Ethereum](https://ethereum.org/en/) compatible tools including Remix, Hardhat, and others. By making a few adjustments to your project’s network configuration settings, you can deploy your new or existing dApp on Celo.
 ```
 
-- [Using thirdweb](/developer/deploy/thirdweb/overview)
-- [Using Remix](/developer/deploy/remix)
-- [Using Hardhat](/developer/deploy/hardhat)
+- [Using thirdweb](/tooling/dev-environments/thirdweb/overview)
+- [Using Remix](/tooling/dev-environments/remix)
+- [Using Hardhat](/tooling/dev-environments/hardhat)
+
+
+
+
+
+

--- a/tooling/dev-environments/remix.mdx
+++ b/tooling/dev-environments/remix.mdx
@@ -92,7 +92,13 @@ To learn more about the features available to you as a smart contract developer 
 
 ## Verify Contracts on Celo
 
-- [Using Blockscout](/developer/verify/blockscout)
-- [Using Remix](/developer/verify/remix)
-- [Using CeloScan](/developer/verify/celoscan)
-- [Using Hardhat](/developer/verify/hardhat)
+- [Using Blockscout](/tooling/contract-verification/blockscout)
+- [Using Remix](/tooling/contract-verification/remix)
+- [Using CeloScan](/tooling/contract-verification/celoscan)
+- [Using Hardhat](/tooling/contract-verification/hardhat)
+
+
+
+
+
+

--- a/tooling/dev-environments/thirdweb/one-click-deploy.mdx
+++ b/tooling/dev-environments/thirdweb/one-click-deploy.mdx
@@ -101,3 +101,9 @@ NFTs. The third and last link will display an NFT along with its description and
 3. You can win up to **`5k USDm`** + Track Bounties.
 4. Build with **`Celo`**.
 
+
+
+
+
+
+

--- a/tooling/dev-environments/thirdweb/overview.mdx
+++ b/tooling/dev-environments/thirdweb/overview.mdx
@@ -45,3 +45,8 @@ Using Thirdweb is recommended because it eliminates the complexity of Web3 devel
 - [Thirdweb Docs](https://portal.thirdweb.com/?utm_source=celo&utm_medium=documentation&utm_campaign=chain_docs)
 - [Playground](https://playground.thirdweb.com/?utm_source=celo&utm_medium=documentation&utm_campaign=chain_docs)
 - [Templates](https://thirdweb.com/templates?utm_source=celo&utm_medium=documentation&utm_campaign=chain_docs)
+
+
+
+
+

--- a/tooling/dev-environments/thirdweb/thirdweb.mdx
+++ b/tooling/dev-environments/thirdweb/thirdweb.mdx
@@ -90,3 +90,9 @@ Deploy allows you to deploy a smart contract to any EVM compatible network witho
 For additional information on Deploy, please reference [thirdweb’s documentation](https://portal.thirdweb.com/deploy).
 
 If you have any further questions or encounter any issues during the process, please reach out to thirdweb support at [support.thirdweb.com](http://support.thirdweb.com/).
+
+
+
+
+
+

--- a/tooling/explorers/analytics.mdx
+++ b/tooling/explorers/analytics.mdx
@@ -36,3 +36,9 @@ For more detailed analytics and insights, consider exploring the following resou
 - <ColoredText>[L2BEAT](https://l2beat.com/scaling/projects/celo)</ColoredText>: L2 analytics and research on Celo.
 - <ColoredText>[growthepie](https://www.growthepie.xyz/chains/celo)</ColoredText>: Ethereum ecosystem analytics and research on Celo.
 - <ColoredText>[DefiLlama](https://defillama.com/chain/celo)</ColoredText>: Open and transparent DeFi analytics on Celo.
+
+
+
+
+
+

--- a/tooling/explorers/block-explorers.mdx
+++ b/tooling/explorers/block-explorers.mdx
@@ -22,3 +22,8 @@ Celoscan block explorer is available for <ColoredText>[Celo](https://celoscan.io
 - View detailed transaction information
 
 A testnet explorer for Celo Sepolia is also available.
+
+
+
+
+

--- a/tooling/explorers/blockscout.mdx
+++ b/tooling/explorers/blockscout.mdx
@@ -2,3 +2,8 @@
 title: Blockscout
 url: "https://celo.blockscout.com/"
 ---
+
+
+
+
+

--- a/tooling/explorers/celoscan.mdx
+++ b/tooling/explorers/celoscan.mdx
@@ -2,3 +2,8 @@
 title: Celoscan
 url: "https://celoscan.io/"
 ---
+
+
+
+
+

--- a/tooling/explorers/overview.mdx
+++ b/tooling/explorers/overview.mdx
@@ -6,9 +6,16 @@ sidebarTitle: "Overview"
 
 import {ColoredText} from "/snippets/ColoredText.jsx";
 
-If you are looking to check your recent transactions or check and interact with a smart contract, check out our <ColoredText>[Block Explorer](/developer/explorers/block-explorers)</ColoredText>.
-If you need historical data for building your dapp, you can find that in the <ColoredText>[Data Indexer](/developer/indexers/overview)</ColoredText> and if you are looking to get an overview on what is happening on Celo, top applications and TVL, check out the <ColoredText>[Analytics](/developer/explorers/analytics)</ColoredText> page.  
+If you are looking to check your recent transactions or check and interact with a smart contract, check out our <ColoredText>[Block Explorer](/tooling/explorers/block-explorers)</ColoredText>.
+If you need historical data for building your dapp, you can find that in the <ColoredText>[Data Indexer](/tooling/indexers/overview)</ColoredText> and if you are looking to get an overview on what is happening on Celo, top applications and TVL, check out the <ColoredText>[Analytics](/tooling/explorers/analytics)</ColoredText> page.  
 
-- [Block Explorers](/developer/explorers/block-explorers)
-- [Data Indexers](/developer/indexers/overview)
-- [Analytics](/developer/explorers/analytics)
+- [Block Explorers](/tooling/explorers/block-explorers)
+- [Data Indexers](/tooling/indexers/overview)
+- [Analytics](/tooling/explorers/analytics)
+
+
+
+
+
+
+

--- a/tooling/indexers/envio.mdx
+++ b/tooling/indexers/envio.mdx
@@ -146,3 +146,9 @@ Envio engineers are available to help you with your data availability needs.
 - Email: [hello@envio.dev](mailto:hello@envio.dev)
 
 
+
+
+
+
+
+

--- a/tooling/indexers/goldrush.mdx
+++ b/tooling/indexers/goldrush.mdx
@@ -16,3 +16,8 @@ The **[GoldRush TypeScript SDK](https://www.npmjs.com/package/@covalenthq/client
 npm install @covalenthq/client-sdk
 ```
 Learn more about GoldRush's integration with Celo [here](https://goldrush.dev/docs/chains/celo?utm_source=celo&utm_medium=partner-docs) .
+
+
+
+
+

--- a/tooling/indexers/indexing-co.mdx
+++ b/tooling/indexers/indexing-co.mdx
@@ -148,3 +148,9 @@ cp -r indexing-co-pipeline-skill/skills/indexing-co-pipelines ~/.claude/skills/
 - [MCP Server](https://github.com/indexing-co/indexing-co-mcp)
 - [Claude Code Skill](https://github.com/indexing-co/indexing-co-pipeline-skill)
 - [Support](mailto:support@indexing.co)
+
+
+
+
+
+

--- a/tooling/indexers/overview.mdx
+++ b/tooling/indexers/overview.mdx
@@ -34,3 +34,9 @@ for querying real-time and historical data.
   - GoldRush offers the most comprehensive Blockchain Data API suite for developers, analysts, and enterprises. Whether you are building a DeFi dashboard, a wallet, a trading bot, an AI agent or a compliance platform, the Data APIs provide fast, accurate, and developer-friendly access to the essential on-chain data you need.
 - [Indexing Co](https://indexing.co)
   - Indexing Co provides custom data pipelines for Celo and 100+ other blockchains, with JavaScript transformation logic, sub-second latency, and delivery to Postgres, webhooks, or Kafka.
+
+
+
+
+
+

--- a/tooling/indexers/subquery.mdx
+++ b/tooling/indexers/subquery.mdx
@@ -22,3 +22,8 @@ SubQuery is open-source, meaning you have the freedom to run it in the following
 - [Locally on your own computer or on your cloud provider of choice.](https://academy.subquery.network/indexer/run_publish/introduction.html#locally-run-it-yourself)
 - [By publishing it to the decentralised SubQuery Network](https://academy.subquery.network/indexer/run_publish/introduction.html#publish-to-the-subquery-network), the most open, performant, reliable, and scalable data service for dApp developers.
 - [Leveraging a centralised hosting partner in the SubQuery community](https://academy.subquery.network/indexer/run_publish/introduction.html#other-hosting-providers-in-the-subquery-community), like OnFinality or Traceye.
+
+
+
+
+

--- a/tooling/indexers/the-graph.mdx
+++ b/tooling/indexers/the-graph.mdx
@@ -208,3 +208,8 @@ axios(graphQLRequest)
 
 - To explore all the ways you can optimize & customize your subgraph for a better performance, read more about [creating a subgraph here](https://thegraph.com/docs/en/developing/creating-a-subgraph/).
 - For more information about querying data from your subgraph, read more [here](https://thegraph.com/docs/en/querying/querying-the-graph/).
+
+
+
+
+

--- a/tooling/libraries-sdks/celo-sdks.mdx
+++ b/tooling/libraries-sdks/celo-sdks.mdx
@@ -22,3 +22,9 @@ Because Celo is compatible with Ethereum any ethereum package can be used with C
 - [Reown](/tooling/libraries-sdks/reown)
 - [Portal](/tooling/libraries-sdks/portal)
 - [JAW](/tooling/libraries-sdks/jaw)
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/account.mdx
+++ b/tooling/libraries-sdks/cli/account.mdx
@@ -1877,3 +1877,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/account/verify-proof-of-possession.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/account/verify-proof-of-possession.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/autocomplete.mdx
+++ b/tooling/libraries-sdks/cli/autocomplete.mdx
@@ -40,3 +40,9 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v3.2.0/src/commands/autocomplete/index.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/commands.mdx
+++ b/tooling/libraries-sdks/cli/commands.mdx
@@ -39,3 +39,9 @@ DESCRIPTION
 ```
 
 _See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/v4.1.21/src/commands/commands.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/config.mdx
+++ b/tooling/libraries-sdks/cli/config.mdx
@@ -81,3 +81,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/config/set.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/config/set.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/election.mdx
+++ b/tooling/libraries-sdks/cli/election.mdx
@@ -424,3 +424,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/election/vote.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/election/vote.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/epochs.mdx
+++ b/tooling/libraries-sdks/cli/epochs.mdx
@@ -400,3 +400,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/epochs/switch.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/epochs/switch.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/governance.mdx
+++ b/tooling/libraries-sdks/cli/governance.mdx
@@ -1507,3 +1507,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/governance/withdraw.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/governance/withdraw.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/help.mdx
+++ b/tooling/libraries-sdks/cli/help.mdx
@@ -29,3 +29,9 @@ DESCRIPTION
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.8/src/commands/help.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/identity.mdx
+++ b/tooling/libraries-sdks/cli/identity.mdx
@@ -70,3 +70,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/identity/withdraw-attestation-rewards.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/identity/withdraw-attestation-rewards.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/index.mdx
+++ b/tooling/libraries-sdks/cli/index.mdx
@@ -114,3 +114,9 @@ For example:
 ```shell
 celocli transfer:celo --to <addressOfChoice> --value 1000000 --from <accountAddress> --useLedger
 ```
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/lockedcelo.mdx
+++ b/tooling/libraries-sdks/cli/lockedcelo.mdx
@@ -575,3 +575,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/lockedcelo/withdraw.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/lockedcelo/withdraw.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/multisig.mdx
+++ b/tooling/libraries-sdks/cli/multisig.mdx
@@ -264,3 +264,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/multisig/transfer.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/multisig/transfer.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/network.mdx
+++ b/tooling/libraries-sdks/cli/network.mdx
@@ -248,3 +248,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/network/whitelist.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/network/whitelist.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/node.mdx
+++ b/tooling/libraries-sdks/cli/node.mdx
@@ -112,3 +112,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/node/synced.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/node/synced.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/oracle.mdx
+++ b/tooling/libraries-sdks/cli/oracle.mdx
@@ -274,3 +274,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/oracle/reports.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/oracle/reports.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/plugins.mdx
+++ b/tooling/libraries-sdks/cli/plugins.mdx
@@ -312,3 +312,9 @@ DESCRIPTION
 ```
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.34/src/commands/plugins/update.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/releasecelo.mdx
+++ b/tooling/libraries-sdks/cli/releasecelo.mdx
@@ -1082,3 +1082,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/releasecelo/withdraw.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/releasecelo/withdraw.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/rewards.mdx
+++ b/tooling/libraries-sdks/cli/rewards.mdx
@@ -75,3 +75,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/rewards/show.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/rewards/show.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/transfer.mdx
+++ b/tooling/libraries-sdks/cli/transfer.mdx
@@ -434,3 +434,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/transfer/stable.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/transfer/stable.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/validator.mdx
+++ b/tooling/libraries-sdks/cli/validator.mdx
@@ -676,3 +676,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/validator/status.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/validator/status.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/cli/validatorgroup.mdx
+++ b/tooling/libraries-sdks/cli/validatorgroup.mdx
@@ -525,3 +525,9 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [src/commands/validatorgroup/show.ts](https://github.com/celo-org/developer-tooling/tree/%40celo/celocli%408.0.0/packages/cli/src/commands/validatorgroup/show.ts)_
+
+
+
+
+
+

--- a/tooling/libraries-sdks/composer-kit.mdx
+++ b/tooling/libraries-sdks/composer-kit.mdx
@@ -215,6 +215,12 @@ For comprehensive examples and detailed API documentation for each component:
 
 ## Next Steps
 
-- Check out the [quickstart guide](/build/quickstart) to get started with Celo development
-- Explore [building on MiniPay](/build/build-on-minipay/overview) for mobile-first experiences
-- Learn about [DeFi integration](/build/build-with-defi) for financial applications
+- Check out the [quickstart guide](/build-on-celo/quickstart) to get started with Celo development
+- Explore [building on MiniPay](/build-on-celo/build-on-minipay/overview) for mobile-first experiences
+- Learn about [DeFi integration](/build-on-celo/build-with-defi) for financial applications
+
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/contracts-wrappers-registry.mdx
+++ b/tooling/libraries-sdks/contractkit/contracts-wrappers-registry.mdx
@@ -9,7 +9,7 @@ How to interact with CELO assets using the wrapper and registry Celo Core Contra
 <Warning>
 [ContractKit has been sunset](https://forum.celo.org/t/sunsetting-contractkit/5337) for external use. Please use viem or wagmi for connecting with the blockchain. 
 
-Check out the [migration guide](/developer/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
+Check out the [migration guide](/tooling/libraries-sdks/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
 
 To learn more visit the [Celo forum](https://forum.celo.org/t/sunsetting-contractkit/5337). 
 </Warning>
@@ -124,3 +124,8 @@ So set the environment variable `DEBUG` as:
 ```bash
 DEBUG="kit:*,
 ```
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/data-encryption-key.mdx
+++ b/tooling/libraries-sdks/contractkit/data-encryption-key.mdx
@@ -5,7 +5,7 @@ title: "Data Encryption Key"
 <Warning>
 [ContractKit has been sunset](https://forum.celo.org/t/sunsetting-contractkit/5337) for external use. Please use viem or wagmi for connecting with the blockchain. 
 
-Check out the [migration guide](/developer/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
+Check out the [migration guide](/tooling/libraries-sdks/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
 
 To learn more visit the [Celo forum](https://forum.celo.org/t/sunsetting-contractkit/5337). 
 </Warning>
@@ -33,3 +33,9 @@ When using the DEK, it's important to check that the DEK is the latest that's re
   // Check that this matches with the public key
   ...
 ```
+
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/index.mdx
+++ b/tooling/libraries-sdks/contractkit/index.mdx
@@ -9,7 +9,7 @@ Overview of ContractKit, its features, purpose, and resources to help you get st
 <Warning>
 [ContractKit has been sunset](https://forum.celo.org/t/sunsetting-contractkit/5337) for external use. Please use viem or wagmi for connecting with the blockchain.
 
-Check out the [migration guide](/developer/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
+Check out the [migration guide](/tooling/libraries-sdks/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
 
 To learn more visit the [Celo forum](https://forum.celo.org/t/sunsetting-contractkit/5337).
 </Warning>
@@ -37,5 +37,10 @@ Contractkit includes common functionality to make it easier to get started build
 
 ## Use ContractKit
 
-- [Setup](/developer/contractkit/setup)
-- [Using the kit](/developer/contractkit/usage)
+- [Setup](/tooling/libraries-sdks/contractkit/setup)
+- [Using the kit](/tooling/libraries-sdks/contractkit/usage)
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/migrating-to-contractkit-v1.mdx
+++ b/tooling/libraries-sdks/contractkit/migrating-to-contractkit-v1.mdx
@@ -8,7 +8,7 @@ How to migrate to from prerelease of ContractKit to v1 and make use of its featu
 <Warning>
 [ContractKit has been sunset](https://forum.celo.org/t/sunsetting-contractkit/5337) for external use. Please use viem or wagmi for connecting with the blockchain. 
 
-Check out the [migration guide](/developer/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
+Check out the [migration guide](/tooling/libraries-sdks/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
 
 To learn more visit the [Celo forum](https://forum.celo.org/t/sunsetting-contractkit/5337). 
 </Warning>
@@ -36,7 +36,7 @@ ContractKit is a suite of packages.
 ### Main packages
 
 - `Connect` handles how we communicate to the our chain nodes. It wraps the `web3` library and has its own `rpcCaller` class, to make custom calls to the node. It's the layer in charge of knowing how and which parameters are added by Celo, connect to the node, build the message, send it and handle those responses.
-- `ContractKit` is a reduced subset of the previous versions of ContractKit. This is the layer in charge of loading and using our [core contracts](/developer/contractkit/contracts-wrappers-registry). Internally, uses the `connect` package described above. It has our contracts generated from the ABIs, their wrappers, and also the logic to make claims.
+- `ContractKit` is a reduced subset of the previous versions of ContractKit. This is the layer in charge of loading and using our [core contracts](/tooling/libraries-sdks/contractkit/contracts-wrappers-registry). Internally, uses the `connect` package described above. It has our contracts generated from the ABIs, their wrappers, and also the logic to make claims.
 
 ### Complementary Packages
 
@@ -129,3 +129,8 @@ The `connection` package update includes implementations of some common web3 fun
 - `kit.web3.eth.sign` --> `kit.connection.sign`
 - `kit.isListening` --> `kit.connection.isListening`
 - `kit.addAccount` --> `kit.connection.addAccount`
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/migrating-to-contractkit-v2.mdx
+++ b/tooling/libraries-sdks/contractkit/migrating-to-contractkit-v2.mdx
@@ -8,7 +8,7 @@ How to migrate from v1 to v2 of the Celo SDK suite of packages and make use of t
 <Warning>
 [ContractKit has been sunset](https://forum.celo.org/t/sunsetting-contractkit/5337) for external use. Please use viem or wagmi for connecting with the blockchain. 
 
-Check out the [migration guide](/developer/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
+Check out the [migration guide](/tooling/libraries-sdks/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
 
 To learn more visit the [Celo forum](https://forum.celo.org/t/sunsetting-contractkit/5337). 
 </Warning>
@@ -222,3 +222,9 @@ If your packages imports any of the following from `@celo/utils` you will need t
 - `compressedPubKey`
 - `decompressPublicKey`
 - `deriveDek`
+
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/migrating-to-viem.mdx
+++ b/tooling/libraries-sdks/contractkit/migrating-to-viem.mdx
@@ -121,7 +121,7 @@ With viem:
 
 I'll show the most "basic" interaction, which is a transfer. On CELO, it comes with a twist, you can transfer 4 currencies, CELO, USDm, EURm, and BRLm.
 
-You can get the addresses on these tokens by heading to the explorer and getting their abi and addresses, or you can also use our [registry contract](/developer/contractkit/contracts-wrappers-registry). You can also use the [`@celo/abis`](https://www.npmjs.com/package/@celo/abis) package to get the ABIs directly.
+You can get the addresses on these tokens by heading to the explorer and getting their abi and addresses, or you can also use our [registry contract](/tooling/libraries-sdks/contractkit/contracts-wrappers-registry). You can also use the [`@celo/abis`](https://www.npmjs.com/package/@celo/abis) package to get the ABIs directly.
 
 ```ts
 import { getContract } from 'viem'
@@ -256,3 +256,9 @@ For more in depth examples and documentation about viem specifically, I highly r
 
 Another interesting application to help you migrate could be StCelo-v2.
 You can checkout the changes going from `react-celo` + `contractkit` to `rainbowkit` + `wagmi` + `viem` in [this pull-request](https://github.com/celo-org/staked-celo-web-app/pull/129).
+
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/notes-web3-with-contractkit.mdx
+++ b/tooling/libraries-sdks/contractkit/notes-web3-with-contractkit.mdx
@@ -47,3 +47,9 @@ This let you use the Web3 instance to interact with node's Json RPC API in a tra
 
 This is also the reason that the `Kit` requires a valid provider from the beginning.
 
+
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/odis.mdx
+++ b/tooling/libraries-sdks/contractkit/odis.mdx
@@ -34,7 +34,7 @@ See [this overview document](/legacy/protocol/identity/odis-use-case-phone-numbe
 
 ## Authentication
 
-Both methods require authentication to the ODIS server, which can be performed by either the main wallet key or the data-encryption key (DEK) associated with the wallet key. This is managed by `AuthSigner`, which can be either a `WalletKeySigner` for a wallet key or an `EncryptionKeySigner` for the DEK. The DEK method is preferred, since it doesn't require the user to access the same key that manages their funds. [You can learn more about DEK here.](/developer/contractkit/data-encryption-key)
+Both methods require authentication to the ODIS server, which can be performed by either the main wallet key or the data-encryption key (DEK) associated with the wallet key. This is managed by `AuthSigner`, which can be either a `WalletKeySigner` for a wallet key or an `EncryptionKeySigner` for the DEK. The DEK method is preferred, since it doesn't require the user to access the same key that manages their funds. [You can learn more about DEK here.](/tooling/libraries-sdks/contractkit/data-encryption-key)
 
 You may use the `EncryptionKeySigner` for your `AuthSigner` by passing in the raw private key:
 
@@ -112,3 +112,8 @@ Instead of querying for all the user's contact's peppers and consuming the user'
 The response will be a subset of the input `e164NumberContacts` that are matched by the matchmaking service.
 
 You can view an example of this call in [our mobile project here](https://github.com/celo-org/wallet/blob/master/packages/mobile/src/identity/matchmaking.ts).
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/setup.mdx
+++ b/tooling/libraries-sdks/contractkit/setup.mdx
@@ -9,7 +9,7 @@ ContractKit requirements, installation, and initialization.
 <Warning>
 [ContractKit has been sunset](https://forum.celo.org/t/sunsetting-contractkit/5337) for external use. Please use viem or wagmi for connecting with the blockchain.
 
-Check out the [migration guide](/developer/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
+Check out the [migration guide](/tooling/libraries-sdks/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
 
 To learn more visit the [Celo forum](https://forum.celo.org/t/sunsetting-contractkit/5337).
 </Warning>
@@ -89,3 +89,8 @@ const web3Instance: Web3 = new Web3(
 
 const kit = newKitFromWeb3(web3Instance);
 ```
+
+
+
+
+

--- a/tooling/libraries-sdks/contractkit/usage.mdx
+++ b/tooling/libraries-sdks/contractkit/usage.mdx
@@ -5,7 +5,7 @@ title: Using the Kit
 <Warning>
 [ContractKit has been sunset](https://forum.celo.org/t/sunsetting-contractkit/5337) for external use. Please use viem or wagmi for connecting with the blockchain. 
 
-Check out the [migration guide](/developer/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
+Check out the [migration guide](/tooling/libraries-sdks/contractkit/migrating-to-viem) for updating your dapp from ContractKit to viem.
 
 To learn more visit the [Celo forum](https://forum.celo.org/t/sunsetting-contractkit/5337). 
 </Warning>
@@ -150,3 +150,9 @@ const goldAmount = await exchange.quoteUsdSell(cUsdBalance);
 const sellTx = await exchange.sellDollar(cUsdBalance, goldAmount).send();
 const sellReceipt = await sellTx.waitReceipt();
 ```
+
+
+
+
+
+

--- a/tooling/libraries-sdks/dynamic/index.mdx
+++ b/tooling/libraries-sdks/dynamic/index.mdx
@@ -74,3 +74,8 @@ Now that you set up Dynamic with **Celo**, there are many additional things you 
 - **Explore how to use the Dynamic SDK** - After your users connect their wallets, you'll want to interact with them for various reasons. You can read more about the SDK in [Dynamic's docs](https://docs.dynamic.xyz/introduction/welcome).
 
 For support, you can also join [Dynamic's Slack Community](https://dynamic.xyz/slack)
+
+
+
+
+

--- a/tooling/libraries-sdks/ethers/index.mdx
+++ b/tooling/libraries-sdks/ethers/index.mdx
@@ -4,9 +4,9 @@ og:description: A minimal wrapper to make Ethers.JS compatible with the Celo net
 ---
 
 <Warning>
-When using Ethers.js on Celo, we suggest using the Celo Ethers.js Wrapper to make Ethers.JS compatible with the Celo network. This means being able to handle [fee abstraction](/developer/fee-abstraction) when opened in MiniPay/ Valora. 
+When using Ethers.js on Celo, we suggest using the Celo Ethers.js Wrapper to make Ethers.JS compatible with the Celo network. This means being able to handle [fee abstraction](/tooling/overview/fee-abstraction) when opened in MiniPay/ Valora. 
 
-[Fee Abstraction](/developer/fee-abstraction) on Celo enables the use of stablecoins like cUSD, USDT and USDC as gas tokens. 
+[Fee Abstraction](/tooling/overview/fee-abstraction) on Celo enables the use of stablecoins like cUSD, USDT and USDC as gas tokens. 
 </Warning>
 
 ## Celo Ethers.JS Wrapper
@@ -101,3 +101,9 @@ const txResponse = await signer.sendTransaction({
   feeCurrency: stableTokenAddress,
 });
 ```
+
+
+
+
+
+

--- a/tooling/libraries-sdks/jaw/index.mdx
+++ b/tooling/libraries-sdks/jaw/index.mdx
@@ -355,3 +355,9 @@ See the [JAW configuration docs](https://docs.jaw.id/configuration) for setup de
 - [JAW Dashboard](https://dashboard.jaw.id/)
 - [Source Code](https://github.com/JustaName-id/jaw-mono)
 - [Example Integrations](https://github.com/JustaName-id/jaw-examples)
+
+
+
+
+
+

--- a/tooling/libraries-sdks/portal/index.mdx
+++ b/tooling/libraries-sdks/portal/index.mdx
@@ -358,3 +358,8 @@ console.log(`✅ Transaction hash: ${txHash}`);
 ### Next Steps
 
 Congratulations! You've successfully integrated Portal with your Celo application. You've created secure MPC wallets for your users and implemented basic transaction functionality. For more comprehensive information about Portal's MPC architecture and additional features, explore the [complete Portal documentation](https://docs.portalhq.io/).
+
+
+
+
+

--- a/tooling/libraries-sdks/reown/index.mdx
+++ b/tooling/libraries-sdks/reown/index.mdx
@@ -23,3 +23,8 @@ Some links to learn more about Reown:
 - [Website](https://reown.com/?utm_source=celo&utm_medium=docs&utm_campaign=backlinks)
 - [Blog](https://reown.com/blog?utm_source=celo&utm_medium=docs&utm_campaign=backlinks)
 - [Docs](https://docs.reown.com/?utm_source=celo&utm_medium=docs&utm_campaign=backlinks)
+
+
+
+
+

--- a/tooling/libraries-sdks/thirdweb-sdk/index.mdx
+++ b/tooling/libraries-sdks/thirdweb-sdk/index.mdx
@@ -289,3 +289,8 @@ By running this command, your application is built for production and stored usi
 This URL serves as a permanent hosting location for your application on the web.
 
 If you have any further questions or encounter any issues during the process, please reach out to thirdweb support at [support.thirdweb.com](https://support.thirdweb.com).
+
+
+
+
+

--- a/tooling/libraries-sdks/viem/index.mdx
+++ b/tooling/libraries-sdks/viem/index.mdx
@@ -53,3 +53,9 @@ async function getGasPrice(client, feeCurrencyAddress?: Address) {
 tx.maxFeePerGas = await getGasPrice(client, tx.feeCurrency);
 ```
 
+
+
+
+
+
+

--- a/tooling/libraries-sdks/web3/index.mdx
+++ b/tooling/libraries-sdks/web3/index.mdx
@@ -11,13 +11,13 @@ sidebarTitle: "Web3.js (deprecated)"
 Web3.js has been sunset in 2024. Please consider using [thirdweb](https://thirdweb.com/?utm_source=celo&utm_medium=documentation&utm_campaign=chain_docs) or viem for your project.
 </Note>
 
-Web3.js was established in 2014, making it the oldest web3 library. With extensive documentation, an active community and modular design, Web3.js is powerful and easy-to-use. It has _support for Celo features (specifically **[Fee Abstraction](/developer/fee-abstraction)** via plugins since version 4.13.1_.
+Web3.js was established in 2014, making it the oldest web3 library. With extensive documentation, an active community and modular design, Web3.js is powerful and easy-to-use. It has _support for Celo features (specifically **[Fee Abstraction](/tooling/overview/fee-abstraction)** via plugins since version 4.13.1_.
 
 To learn more about building with Web3.js, check out their [docs](https://docs.web3js.org/) as they have excellent examples of how to use it in your project.
 
 ### Fee Abstraction with Web3.js
 
-[Fee Abstraction](/developer/fee-abstraction) on Celo enables the use of stablecoins like cUSD, USDT and USDC as gas tokens. 
+[Fee Abstraction](/tooling/overview/fee-abstraction) on Celo enables the use of stablecoins like cUSD, USDT and USDC as gas tokens. 
 
 #### Requirements
 
@@ -25,7 +25,7 @@ To learn more about building with Web3.js, check out their [docs](https://docs.w
 
 #### Install the Celo Web3.js Plugin
 
-For Celo' specific features like [Fee Abstraction](/developer/fee-abstraction) transactions you need to install `@celo/web3-plugin-transaction-types` as well as `web3@4.13.1` or higher. This also adds utils like `getCoreContractAddress` for fetching core contract address from onchain registry. This is useful to get the stablecoin addresses you are planning to use programmatically. Make sure they are listed in the [**FeeCurrencyDirectory.sol**](/contracts/core-contracts).
+For Celo' specific features like [Fee Abstraction](/tooling/overview/fee-abstraction) transactions you need to install `@celo/web3-plugin-transaction-types` as well as `web3@4.13.1` or higher. This also adds utils like `getCoreContractAddress` for fetching core contract address from onchain registry. This is useful to get the stablecoin addresses you are planning to use programmatically. Make sure they are listed in the [**FeeCurrencyDirectory.sol**](/tooling/contracts/core-contracts).
 
 {/* prettier-ignore-start */}
 
@@ -79,3 +79,9 @@ await web3.celo.populateTransaction(txData);
 ```
 
 You can find more examples in the [github repository readme](https://github.com/celo-org/web3-plugin-transaction-types).
+
+
+
+
+
+

--- a/tooling/nodes/alchemy.mdx
+++ b/tooling/nodes/alchemy.mdx
@@ -24,3 +24,9 @@ This guide assumes you already have an Alchemy account and access to our Dashboa
 - [Celo API Overview](https://docs.alchemy.com/reference/chain-apis-overview#celo-apis)
 - [Celo API Endpoints](https://docs.alchemy.com/reference/celo-chain-api-endpoints)
 - [Celo FAQs](https://docs.alchemy.com/reference/celo-chain-api-faq)
+
+
+
+
+
+

--- a/tooling/nodes/forno.mdx
+++ b/tooling/nodes/forno.mdx
@@ -55,3 +55,9 @@ wss://forno.celo-sepolia.celo-testnet.org/ws
 Websocket connections are useful for listening to logs (events) emitted by smart contracts. However, Forno automatically disconnects websocket connections after 20 minutes.
 
 When disconnected, you can reconnect to the websocket endpoint to continue listening for events. [This example script](https://gist.github.com/critesjosh/a230e7b2eb54c8d330ca57db1f6239db) demonstrates how to set up an event listener that automatically reconnects when the connection drops.
+
+
+
+
+
+

--- a/tooling/nodes/overview.mdx
+++ b/tooling/nodes/overview.mdx
@@ -208,3 +208,8 @@ https://onfinality.io/networks/celo
 <Card href="https://getblock.io/nodes/celo/" arrow title="GetBlock">
 https://getblock.io/nodes/celo/
 </Card>
+
+
+
+
+

--- a/tooling/nodes/run-a-celo-node.mdx
+++ b/tooling/nodes/run-a-celo-node.mdx
@@ -2,3 +2,8 @@
 title: Run a Celo Node
 url: https://docs.celo.org/cel2/operators/run-node
 ---
+
+
+
+
+

--- a/tooling/oracles/band-protocol.mdx
+++ b/tooling/oracles/band-protocol.mdx
@@ -71,3 +71,9 @@ You can view the available reference data on the [Band Data site here](https://d
 ## Bandchain.js
 
 Band also has a javascript library that makes it easy to interact with BandChain directly from Javascript or Typescript applications. The library provides classes and methods for convenient to send transactions, query data, OBI encoding, and wallet management. You can [read more about it here](https://docs.bandchain.org/develop/developer-tools/bandchain.js/getting-started).
+
+
+
+
+
+

--- a/tooling/oracles/chainlink-oracles.mdx
+++ b/tooling/oracles/chainlink-oracles.mdx
@@ -60,3 +60,9 @@ For more detailed information about Chainlink CCIP, please refer to the [Chainli
 ## Need Assistance?
 
 For any questions, please feel free to contact the Chainlink team [on Discord](https://discord.gg/aSK4zew).
+
+
+
+
+
+

--- a/tooling/oracles/index.mdx
+++ b/tooling/oracles/index.mdx
@@ -10,13 +10,19 @@ Oracles are essential components in blockchain ecosystems, acting as bridges tha
 
 Here are lists of all on-chain Oracles:
 
-- [RedStone Oracles](/developer/oracles/redstone)
+- [RedStone Oracles](/tooling/oracles/redstone)
 - [Chainlink, Price Feed Oracles](https://docs.chain.link/data-feeds/price-feeds/addresses?network=celo)
-- [Band](/developer/oracles/band-protocol)
+- [Band](/tooling/oracles/band-protocol)
 - [Celo Reserve Oracles](/legacy/protocol/stability/oracles)
 - [Supra](https://supraoracles.com/)
 - [Pyth Network](https://pyth.network/)
   - Randomness
-- [Witnet](/developer/oracles/wit-oracle)
-  - [Randomness](/developer/oracles/wit-oracle/#how-to-use-witnetrandomness)
-- [Quex Oracles](/developer/oracles/quex-oracles)
+- [Witnet](/tooling/oracles/wit-oracle)
+  - [Randomness](/tooling/oracles/wit-oracle/#how-to-use-witnetrandomness)
+- [Quex Oracles](/tooling/oracles/quex-oracles)
+
+
+
+
+
+

--- a/tooling/oracles/quex-oracles.mdx
+++ b/tooling/oracles/quex-oracles.mdx
@@ -50,3 +50,8 @@ Please read this [short getting started guide](https://docs.quex.tech/developers
 ## 🙋‍♂️ Need help?
 
 Feel free to reach out to the Quex team [on Discord](https://discord.com/invite/NsuE32xHvj) if you have any questions.
+
+
+
+
+

--- a/tooling/oracles/redstone.mdx
+++ b/tooling/oracles/redstone.mdx
@@ -46,3 +46,9 @@ Please read this [short documentation](https://github.com/redstone-finance/redst
 ## 🙋‍♂️ Need help?
 
 Please feel free to contact RedStone team [on Discord](https://redstone.finance/discord) if you have any questions.
+
+
+
+
+
+

--- a/tooling/oracles/run.mdx
+++ b/tooling/oracles/run.mdx
@@ -138,3 +138,8 @@ There are two public dashboards deployed where the community can watch how indiv
 ## Building from source
 
 Instructions can be found in the [development documentation](https://github.com/celo-org/celo-oracle#running).
+
+
+
+
+

--- a/tooling/oracles/supra.mdx
+++ b/tooling/oracles/supra.mdx
@@ -10,3 +10,9 @@ sidebarTitle: "Using Supra"
 [Supra](https://supra.com) provides decentralized oracle price feeds that can be used for on-chain and off-chain use-cases such as spot and perpetual DEXes, lending protocols, and payments protocols. Supra’s oracle chain and consensus algorithm makes it the fastest-to-finality oracle provider, with layer-1 security guarantees. The pull oracle has a sub-second response time. Aside from speed and security, Supra’s rotating node architecture gathers data from 40+ data sources and applies a robust calculation methodology to get the most accurate value. The node provenance on the data dashboard also provides a fully transparent historical audit trail. Supra’s Distributed Oracle Agreement (DORA) paper was accepted into ICDCS 2023, the oldest distributed systems conference.
 
 Check out our developer docs [here](https://docs.supra.com/oracles/overview).
+
+
+
+
+
+

--- a/tooling/oracles/wit-oracle.mdx
+++ b/tooling/oracles/wit-oracle.mdx
@@ -144,3 +144,9 @@ For more information about Wit/Oracle please refer to:
 
 [website](https://witnet.io/) | [docs](https://docs.witnet.io/) | [github](https://github.com/witnet) | [twitter](https://twitter.com/witnet_io) | [telegram](https://t.me/witnetio) | [discord](https://discord.gg/witnet) 
 
+
+
+
+
+
+

--- a/tooling/overview/faucet.mdx
+++ b/tooling/overview/faucet.mdx
@@ -2,3 +2,8 @@
 title: Faucet
 url: https://faucet.celo.org/celo-sepolia
 ---
+
+
+
+
+

--- a/tooling/overview/fee-abstraction.mdx
+++ b/tooling/overview/fee-abstraction.mdx
@@ -4,7 +4,7 @@ og:description: How to allow your wallet users to pay for gas fees using alterna
 sidebarTitle: "Fee Abstraction"
 ---
 
-Celo allows users to pay gas fees in currencies other than the native CELO token. The list of accepted tokens is governed on-chain and maintained in [**FeeCurrencyDirectory.sol**](/contracts/core-contracts).
+Celo allows users to pay gas fees in currencies other than the native CELO token. The list of accepted tokens is governed on-chain and maintained in [**FeeCurrencyDirectory.sol**](/tooling/contracts/core-contracts).
 
 To use an alternate fee currency, set its token or adapter address as the `feeCurrency` property on the transaction object. This field is exclusive to Celo. Leaving it empty defaults to CELO. Note that transactions specifying a non-CELO fee currency cost approximately 50,000 additional gas.
 
@@ -206,3 +206,9 @@ async function send(amountInWei) {
 ---
 
 If you have any questions, please [reach out](https://github.com/celo-org/developer-tooling/discussions/categories/q-a).
+
+
+
+
+
+

--- a/tooling/overview/index.mdx
+++ b/tooling/overview/index.mdx
@@ -11,23 +11,28 @@ Explore our comprehensive suite of tools, guides, and resources designed to help
 
 Celo Composer allows you to quickly build, deploy, and iterate on decentralized applications using Celo. It provides a number of frameworks, examples, and Celo specific functionality to help you get started with your next dApp.
 
-- [Quickstart with Celo Composer](/build/quickstart)
+- [Quickstart with Celo Composer](/build-on-celo/quickstart)
 - [Celo Composer GitHub](https://github.com/celo-org/celo-composer)
 
 ## Developer Tools
 
 - [Nodes](/tooling/nodes/overview)
-- [Explorers](/developer/explorers/overview)
-- [Indexers](/developer/indexers/overview)
-- [Bridges](/developer/bridges)
+- [Explorers](/tooling/explorers/overview)
+- [Indexers](/tooling/indexers/overview)
+- [Bridges](/tooling/bridges/bridges)
 - [Testnet Faucet](https://faucet.celo.org/celo-sepolia)
 
 ## Developer Environments
 
-- [Using thirdweb](/developer/deploy/thirdweb/overview)
-- [Using Remix](/developer/deploy/remix)
-- [Using Hardhat](/developer/deploy/hardhat)
+- [Using thirdweb](/tooling/dev-environments/thirdweb/overview)
+- [Using Remix](/tooling/dev-environments/remix)
+- [Using Hardhat](/tooling/dev-environments/hardhat)
 
 ## Code Courses
 
 - [Dacade](https://dacade.org/communities/celo)
+
+
+
+
+

--- a/tooling/overview/migrate/from-ethereum.mdx
+++ b/tooling/overview/migrate/from-ethereum.mdx
@@ -109,3 +109,8 @@ Logs created by these contract changes are included in a single additional recei
 ### Node management APIs
 
 You can find the full list of RPC API endpoints in [this file](https://github.com/celo-org/op-geth/blob/celo-rebase-12/internal/web3ext/web3ext.go).
+
+
+
+
+

--- a/tooling/overview/setup/development-chain.mdx
+++ b/tooling/overview/setup/development-chain.mdx
@@ -10,7 +10,7 @@ How to set up a Celo development blockchain that includes all of the [core proto
 
 ## What to expect
 
-At the end of this tutorial, you will have a local Celo development blockchain running exposed at `http://localhost:7545` and will be able to connect to it like any other local node. We will also go over how to inspect the development blockchain using the [Celo CLI tool](/cli/) and the [ContractKit](/developer/contractkit/).
+At the end of this tutorial, you will have a local Celo development blockchain running exposed at `http://localhost:7545` and will be able to connect to it like any other local node. We will also go over how to inspect the development blockchain using the [Celo CLI tool](/cli/) and the [ContractKit](/tooling/libraries-sdks/contractkit/).
 
 Running the development Celo blockchain is helpful because it greatly speeds up development time. You will start with 10 accounts pre-funded with CELO and all transactions on the network are virtually instant.
 
@@ -46,7 +46,7 @@ Once you custom chain data is generated, you can run it locally with the followi
 
 Now that we have a Celo development chain running, we probably want to know what accounts we have access to, how much cGLD and USDm they have as well as the addresses of the deployed protocol contracts.
 
-We can use the [Celo CLI tool](/cli/) for this, or we can use the [ContractKit](/developer/contractkit/) npm package in a node script.
+We can use the [Celo CLI tool](/cli/) for this, or we can use the [ContractKit](/tooling/libraries-sdks/contractkit/) npm package in a node script.
 
 ### **Celo CLI**
 
@@ -83,7 +83,7 @@ pending: 0
 
 ### ContractKit + Node.js
 
-You can also use the [ContractKit](/developer/contractkit/) to access the local node in a node.js script.
+You can also use the [ContractKit](/tooling/libraries-sdks/contractkit/) to access the local node in a node.js script.
 
 As an example, try running [this script](https://gist.github.com/critesjosh/35ba7b1c2fe41934308cb243b003001c) in an npm project with contractkit installed.
 
@@ -96,3 +96,9 @@ You are now prepared to start developing, transacting and deploying contracts on
 You can connect the development chain to a tool like [Remix](https://remix.ethereum.org/) to begin interacting with it. Keep in mind that these tools are built primarily for Ethereum development and are compatible with Celo because Celo is similar to Ethereum. The two blockchains have similar block architectures and both run the Ethereum Virtual Machine \(EVM\) for executing smart contracts.
 
 The main difference between Celo and Ethereum that dapp developers need to keep in mind is that Celo has a slightly different transaction object than Ethereum. Celo requires one additional field in a transaction object, a `feeCurrency`. When Remix is connected to a locally running Celo node, the local node will fill these fields with default values \(if the fields are empty\). The node will sign the Celo transaction and broadcast it to the network.
+
+
+
+
+
+

--- a/tooling/overview/setup/mac.mdx
+++ b/tooling/overview/setup/mac.mdx
@@ -255,3 +255,8 @@ Then make sure the ADB path is set correctly in Genymotion — set Preferences >
 [Solidity support for VSCode](https://marketplace.visualstudio.com/items?itemName=JuanBlanco.solidity) (or your preferred IDE/text editor)
 
 Celo smart contracts are written in Solidity. While Solidity syntax is very similar to JavaScript/TypeScript, there are some differences and JS syntax support will not like Solidity files. Installing an extension on your IDE will be a big help as you develop smart contracts.
+
+
+
+
+

--- a/tooling/overview/setup/overview.mdx
+++ b/tooling/overview/setup/overview.mdx
@@ -12,3 +12,9 @@ Set up your Celo development environment.
 - [Using Windows](/tooling/overview/setup/windows)
 - [Using Replit](/tooling/overview/setup/replit)
 - [Testnet Wallet](/tooling/overview/setup/wallet)
+
+
+
+
+
+

--- a/tooling/overview/setup/replit.mdx
+++ b/tooling/overview/setup/replit.mdx
@@ -152,3 +152,8 @@ Your project is now available for other developers to view, share, fork, and com
 <Tip>
 Learn more at [Replit.com](https://replit.com/) and in the [Replit documentation](https://docs.replit.com/). Share new projects using **#Celo** and search other **#Celo** tags to find the latest Replit dApps deployed on Celo.
 </Tip>
+
+
+
+
+

--- a/tooling/overview/setup/wallet.mdx
+++ b/tooling/overview/setup/wallet.mdx
@@ -98,3 +98,9 @@ No matter where you created your accounts, you can send them testnet funds using
 </Frame>
 
 Wait for the transaction to process to view the funds in your account.
+
+
+
+
+
+

--- a/tooling/overview/setup/windows.mdx
+++ b/tooling/overview/setup/windows.mdx
@@ -72,3 +72,8 @@ You are good to go! If you have any questions, [join our Discord server](https:/
 
 - [**Windows Subsystem for Linux Installation Guide for Windows 10**](https://docs.microsoft.com/en-us/windows/wsl/install-win10?WT.mc_id=smashingmag-article-buhollan)
 - [**WSL: Ultimate Guide**](https://adamtheautomator.com/windows-subsystem-for-linux/#developing-on-wsl-with-visual-studio-code-vs-code-)
+
+
+
+
+

--- a/tooling/testnets/celo-sepolia/disclaimer.mdx
+++ b/tooling/testnets/celo-sepolia/disclaimer.mdx
@@ -20,3 +20,8 @@ To the fullest extent permitted by law, in no event shall the Parties Involved h
 The Celo Labs software is not subject to the EAR based on Section 734.7 of the U.S. Export Administration Regulations \("EAR", 15 CFR Parts 730-774\) and Section 742.15\(b\) of the EAR, which applies to software containing or designed for use with encryption software that is publicly available as open-source. However, products developed using the Celo Labs software may be subject to the EAR or local laws/regulations. The User is responsible for compliance with U.S. and local country export/import laws and regulations.
 
 Celo Labs software may not be exported/reexported, either directly or indirectly, to any destination subject to U.S. embargoes or trade sanctions unless formally authorized by the U.S. Government. The embargoed destinations are subject to change and the scope of what is included in the embargo is specific to each embargoed country. For the most current information on U.S. embargoed and sanctioned countries, see the [Treasury Department regulations](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx).
+
+
+
+
+

--- a/tooling/testnets/celo-sepolia/index.mdx
+++ b/tooling/testnets/celo-sepolia/index.mdx
@@ -52,3 +52,8 @@ For developers currently using Alfajores, consider the following when migrating 
 ## Network Configuration
 
 For detailed network configuration including RPC endpoints, contract addresses, and P2P peer information, see the [Running a Node guide](/infra-partners/operators/run-node#celo-sepolia).
+
+
+
+
+

--- a/tooling/wallets/coinbase-wallet.mdx
+++ b/tooling/wallets/coinbase-wallet.mdx
@@ -69,5 +69,11 @@ await window.ethereum.request({
 - Where it says `INSERT_SYMBOL_HERE`, please replace with the correct symbol for the asset you'd like to watch. For Mento Dollar, it's `USDm` and for Mento Euro, it's `EURm`.
 
 <Tip>
-View available token addresses for Celo assets to add to Coinbase Wallet [here](/contracts/token-contracts).
+View available token addresses for Celo assets to add to Coinbase Wallet [here](/tooling/contracts/token-contracts).
 </Tip>
+
+
+
+
+
+

--- a/tooling/wallets/index.mdx
+++ b/tooling/wallets/index.mdx
@@ -12,7 +12,7 @@ Overview of digital wallets available to send, spend, and earn Celo assets.
 
 Celo is designed to work seamlessly with a range of wallets, each offering features to meet different user needs.
 
-The [Celo Native Wallets](#celo-native-wallets) section provides an overview of wallets that are optimized for the Celo network. These wallets allow users to fully benefit from Celo’s native functionalities, such as [phone number mapping](/legacy/protocol/identity) and [fee abstraction](/developer/fee-abstraction).
+The [Celo Native Wallets](#celo-native-wallets) section provides an overview of wallets that are optimized for the Celo network. These wallets allow users to fully benefit from Celo’s native functionalities, such as [phone number mapping](/legacy/protocol/identity) and [fee abstraction](/tooling/overview/fee-abstraction).
 
 The [Wallet Infrastructure](#wallet-infrastructure) section provides an overview of wallet infrastructure solutions you can integrate into your dapp to enable seamless web3 interactions for your users.
 
@@ -31,7 +31,7 @@ MiniPay is a non-custodial lightweight mobile wallet that allows users to send a
 - Maintainers: Opera
 - Ledger support: No
 - Supported tokens: USDm, USDT, and USDC
-- [Start building](/build/build-on-minipay/quickstart)
+- [Start building](/build-on-celo/build-on-minipay/quickstart)
 
 ---
 
@@ -159,3 +159,9 @@ JAW provides smart account infrastructure for Celo applications. Give users pass
 - [Docs](https://docs.jaw.id/)
 - [Source Code](https://github.com/JustaName-id/jaw-mono)
 - [Dashboard](https://dashboard.jaw.id/)
+
+
+
+
+
+

--- a/tooling/wallets/ledger/eip712-workaround.mdx
+++ b/tooling/wallets/ledger/eip712-workaround.mdx
@@ -149,3 +149,9 @@ If you continue to experience issues:
 ## Future Updates
 
 The Celo community is working on adding native EIP-712 support to the Celo Ledger app. Once this feature is implemented, this workaround will no longer be necessary.
+
+
+
+
+
+

--- a/tooling/wallets/ledger/setup.mdx
+++ b/tooling/wallets/ledger/setup.mdx
@@ -80,3 +80,8 @@ The Celo Ledger app currently does not support signing EIP-712 typed data, which
 
 If you need to sign EIP-712 transactions, you'll need to use the **Eth Recovery app** as a workaround. See the [EIP-712 Signing Workaround guide](/wallet/ledger/eip712-workaround) for detailed instructions.
 </Warning>
+
+
+
+
+

--- a/tooling/wallets/ledger/to-celo-cli.mdx
+++ b/tooling/wallets/ledger/to-celo-cli.mdx
@@ -160,3 +160,8 @@ If you have issues connecting to the Ledger, try the following:
 - Ensure that you are running the latest version of the Celo CLI.
 
 There have been reports of a possible [issue](https://github.com/celo-org/celo-ledger-spender-app-archived) that appears to affect developer store apps on the Ledger Nano X including the Celo Ledger App. This is believed to be fixed in version 1.0.3. In earlier versions, a user clicking through the `Pending Ledger review` notice too rapidly can cause the device to freeze. If this occurs, wait until the device's battery is depleted, then charge and power up again. Then use Ledger Wallet Manager to update the installed version of the Celo Ledger App.
+
+
+
+
+

--- a/tooling/wallets/ledger/to-celo-terminal.mdx
+++ b/tooling/wallets/ledger/to-celo-terminal.mdx
@@ -52,3 +52,8 @@ The Celo Ledger app currently does not support signing EIP-712 typed data, which
 
 If you need to sign EIP-712 transactions, see the [EIP-712 Signing Workaround guide](/wallet/ledger/eip712-workaround) for detailed instructions on using the Eth Recovery app.
 </Warning>
+
+
+
+
+

--- a/tooling/wallets/ledger/to-celo-web.mdx
+++ b/tooling/wallets/ledger/to-celo-web.mdx
@@ -42,3 +42,8 @@ Plugin your ledger device and select connect.
 </Frame>
 
 Congrats, you have successfully attached your Ledger account to Celo Wallet.
+
+
+
+
+

--- a/tooling/wallets/metamask/add-celo-testnet-to-metamask.mdx
+++ b/tooling/wallets/metamask/add-celo-testnet-to-metamask.mdx
@@ -42,3 +42,9 @@ Follow this quick guide to add Celo Sepolia to your MetaMask wallet and start pl
   </Frame>
 
 5. Click "Save"
+
+
+
+
+
+

--- a/tooling/wallets/metamask/import.mdx
+++ b/tooling/wallets/metamask/import.mdx
@@ -109,3 +109,8 @@ MetaMask is now connected to your Valora wallet. The value of your Valora wallet
 <Info>
 You may now delete your project directory along with the text file used to store your wallet address.
 </Info>
+
+
+
+
+

--- a/tooling/wallets/metamask/setup.mdx
+++ b/tooling/wallets/metamask/setup.mdx
@@ -73,9 +73,15 @@ await window.ethereum.request({
 - Where it says `INSERT_SYMBOL_HERE`, please replace with the correct symbol for the asset you'd like to watch. For Mento Dollar, it's `USDm` and for Mento Euro, it's `EURm`.
 
 <Tip>
-View available token addresses for Celo assets to add to MetaMask [here](/contracts/token-contracts).
+View available token addresses for Celo assets to add to MetaMask [here](/tooling/contracts/token-contracts).
 </Tip>
 
 <Warning>
 We strongly suggest that you disable your dApp's functionality when MetaMask is connected to a non-Celo network. MetaMask has an API for determining what network/chain you're connected to. [See here](https://docs.metamask.io/guide/ethereum-provider.html#methods) for more documentation around that.
 </Warning>
+
+
+
+
+
+

--- a/tooling/wallets/metamask/use.mdx
+++ b/tooling/wallets/metamask/use.mdx
@@ -50,3 +50,8 @@ In some cases, the MetaMask UI may display the Ethereum logo in places where it 
 <Note>
 MetaMask is primarily used for interacting with the Ethereum blockchain and does not natively support Celo compatibility. Alternatively, you may choose a Celo native wallet [here](/wallet/metamask/setup).
 </Note>
+
+
+
+
+


### PR DESCRIPTION
This PR resolves over 360 broken internal links that were using outdated URL prefixes (`/developer/`, `/build/`, and `/contracts/`) by updating them to the current structure (`/tooling/`, `/build-on-celo/`).

Key Improvements:
- **Link Fixes**: Fixed hundreds of broken internal navigation links.
- **Typo Corrections**: Fixed "uses cases" -> "use cases", "Compatibile" -> "Compatible", and singular/plural grammar in the L2 migration summary.
- **Improved Quickstart**: Corrected "Checkout" to "Check out" for better grammar.
- **Better Formatting**: Converted raw audit URLs into clickable Markdown links.

These fixes significantly improve the user experience and professional quality of the documentation.
