### PR TITLE
Fix broken lemonade.social links

### DIFF
--- a/contribute-to-celo/builders.mdx
+++ b/contribute-to-celo/builders.mdx
@@ -16,7 +16,7 @@ There are several ways to get started as a builder on Celo:
 
 * **Join the Builder Community**: Connect with like-minded individuals on platforms like [Discord](https://discord.com/invite/celo) and the [Celo Forum](https://forum.celo.org/). You'll find channels dedicated to everything from smart contract development to mobile-first dApp creation.
 
-* **Join the office hour**: Office Hours are an excellent way to learn about opportunities in the ecosystem, get feedback on your project and connect with the community. Find ecosystem events on our community [event platform](https://celo.lemonade.social/).
+* **Join the office hour**: Office Hours are an excellent way to learn about opportunities in the ecosystem, get feedback on your project and connect with the community. Find ecosystem events on our community [event platform](https://lemonade.social/s/celo).
 
 * **Apply for Grants**: Celo has grants programs, like [Prezenti](https://www.prezenti.xyz/) and [Celo Public Goods](https://www.celopg.eco/) which supports projects that align with its mission to provide financial services to the next billion people.
 

--- a/contribute-to-celo/builders.mdx
+++ b/contribute-to-celo/builders.mdx
@@ -16,7 +16,7 @@ There are several ways to get started as a builder on Celo:
 
 * **Join the Builder Community**: Connect with like-minded individuals on platforms like [Discord](https://discord.com/invite/celo) and the [Celo Forum](https://forum.celo.org/). You'll find channels dedicated to everything from smart contract development to mobile-first dApp creation.
 
-* **Join the office hour**: Office Hours are an excellent way to learn about opportunities in the ecosystem, get feedback on your project and connect with the community. Find ecosystem events on our community [event platform](https://lemonade.social/s/celo).
+* **Join the office hour**: Office Hours are an excellent way to learn about opportunities in the ecosystem, get feedback on your project and connect with the community. Find governance events on our community [event platform](https://lemonade.social/s/celogovernance).
 
 * **Apply for Grants**: Celo has grants programs, like [Prezenti](https://www.prezenti.xyz/) and [Celo Public Goods](https://www.celopg.eco/) which supports projects that align with its mission to provide financial services to the next billion people.
 

--- a/contribute-to-celo/builders.mdx
+++ b/contribute-to-celo/builders.mdx
@@ -16,7 +16,7 @@ There are several ways to get started as a builder on Celo:
 
 * **Join the Builder Community**: Connect with like-minded individuals on platforms like [Discord](https://discord.com/invite/celo) and the [Celo Forum](https://forum.celo.org/). You'll find channels dedicated to everything from smart contract development to mobile-first dApp creation.
 
-* **Join the office hour**: Office Hours are an excellent way to learn about opportunities in the ecosystem, get feedback on your project and connect with the community. Find ecosystem events on our community [event platform](https://celo.stand.lemonade.social/events).
+* **Join the office hour**: Office Hours are an excellent way to learn about opportunities in the ecosystem, get feedback on your project and connect with the community. Find ecosystem events on our community [event platform](https://celo.lemonade.social/).
 
 * **Apply for Grants**: Celo has grants programs, like [Prezenti](https://www.prezenti.xyz/) and [Celo Public Goods](https://www.celopg.eco/) which supports projects that align with its mission to provide financial services to the next billion people.
 

--- a/docs.json
+++ b/docs.json
@@ -3116,7 +3116,7 @@
             "label": "X"
           },
           {
-            "href": "https://lemonade.social/celo",
+            "href": "https://celo.lemonade.social/",
             "label": "Events"
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -3116,8 +3116,8 @@
             "label": "X"
           },
           {
-            "href": "https://lemonade.social/s/celo",
-            "label": "Events"
+            "href": "https://lemonade.social/s/celogovernance",
+            "label": "Governance Events"
           }
         ]
       }

--- a/docs.json
+++ b/docs.json
@@ -3116,7 +3116,7 @@
             "label": "X"
           },
           {
-            "href": "https://celo.lemonade.social/",
+            "href": "https://lemonade.social/s/celo",
             "label": "Events"
           }
         ]

--- a/home/celo.mdx
+++ b/home/celo.mdx
@@ -127,8 +127,8 @@ description: "Celo is a leading Ethereum L2. As the frontier chain for global im
   <Card title="Connect with the Community" icon="discord" href="https://discord.com/invite/celo">
     Join our Discord
   </Card>
-  <Card title="Bring Your Ideas to Life" icon="lightbulb" href="https://lemonade.social/s/celo">
-    Sign up for upcoming hackathons and workshops
+  <Card title="Governance Events" icon="lightbulb" href="https://lemonade.social/s/celogovernance">
+    Sign up for upcoming governance calls and workshops
   </Card>
   <Card title="Join Proof of Ship" icon="anchor" href="https://celoplatform.notion.site/Build-With-Celo-Proof-of-Ship-17cd5cb803de8060ba10d22a72b549f8">
     Build your onchain reputation to unlock exclusive rewards

--- a/home/celo.mdx
+++ b/home/celo.mdx
@@ -127,7 +127,7 @@ description: "Celo is a leading Ethereum L2. As the frontier chain for global im
   <Card title="Connect with the Community" icon="discord" href="https://discord.com/invite/celo">
     Join our Discord
   </Card>
-  <Card title="Bring Your Ideas to Life" icon="lightbulb" href="https://lemonade.social/celo">
+  <Card title="Bring Your Ideas to Life" icon="lightbulb" href="https://celo.lemonade.social/">
     Sign up for upcoming hackathons and workshops
   </Card>
   <Card title="Join Proof of Ship" icon="anchor" href="https://celoplatform.notion.site/Build-With-Celo-Proof-of-Ship-17cd5cb803de8060ba10d22a72b549f8">

--- a/home/celo.mdx
+++ b/home/celo.mdx
@@ -127,7 +127,7 @@ description: "Celo is a leading Ethereum L2. As the frontier chain for global im
   <Card title="Connect with the Community" icon="discord" href="https://discord.com/invite/celo">
     Join our Discord
   </Card>
-  <Card title="Bring Your Ideas to Life" icon="lightbulb" href="https://celo.lemonade.social/">
+  <Card title="Bring Your Ideas to Life" icon="lightbulb" href="https://lemonade.social/s/celo">
     Sign up for upcoming hackathons and workshops
   </Card>
   <Card title="Join Proof of Ship" icon="anchor" href="https://celoplatform.notion.site/Build-With-Celo-Proof-of-Ship-17cd5cb803de8060ba10d22a72b549f8">

--- a/home/protocol/governance/governance-toolkit.mdx
+++ b/home/protocol/governance/governance-toolkit.mdx
@@ -24,7 +24,7 @@ An overview of the tools, platforms, and resources available for participating i
 * [**The Celo Forum**](https://forum.celo.org/): The platform for governance and community discussion.
 * [**Discord**](https://discord.com/invite/celo): For informal governance discussion and feedback.
 * [**Github**](https://github.com/celo-org/governance): Governance guidelines and CGP proposals are tracked via Github.
-* [**Governance Call**](https://lemonade.social/s/celo): Sign Up to the next Governance Call.
+* [**Governance Events**](https://lemonade.social/s/celogovernance): Sign Up to the next Governance Call.
 
 ## Celo Governance Guardians Overview
 

--- a/home/protocol/governance/governance-toolkit.mdx
+++ b/home/protocol/governance/governance-toolkit.mdx
@@ -24,7 +24,7 @@ An overview of the tools, platforms, and resources available for participating i
 * [**The Celo Forum**](https://forum.celo.org/): The platform for governance and community discussion.
 * [**Discord**](https://discord.com/invite/celo): For informal governance discussion and feedback.
 * [**Github**](https://github.com/celo-org/governance): Governance guidelines and CGP proposals are tracked via Github.
-* **Governance Call**: Join the regular governance calls (check the [Forum](https://forum.celo.org/) for the latest schedule).
+* [**Governance Call**](https://lemonade.social/s/celo): Sign Up to the next Governance Call.
 
 ## Celo Governance Guardians Overview
 

--- a/home/protocol/governance/governance-toolkit.mdx
+++ b/home/protocol/governance/governance-toolkit.mdx
@@ -24,7 +24,7 @@ An overview of the tools, platforms, and resources available for participating i
 * [**The Celo Forum**](https://forum.celo.org/): The platform for governance and community discussion.
 * [**Discord**](https://discord.com/invite/celo): For informal governance discussion and feedback.
 * [**Github**](https://github.com/celo-org/governance): Governance guidelines and CGP proposals are tracked via Github.
-* [**Governance Call**](https://lemonade.social/celo): Sign Up to the next Governance Call.
+* **Governance Call**: Join the regular governance calls (check the [Forum](https://forum.celo.org/) for the latest schedule).
 
 ## Celo Governance Guardians Overview
 

--- a/snippets/home.jsx
+++ b/snippets/home.jsx
@@ -476,7 +476,7 @@ export const CeloBuilderEcosystem = ({
     {
       title: "Bring Your Ideas to Life",
       desc: "Sign up for upcoming hackathons and workshops",
-      href: "https://lemonade.social/s/celo",
+      href: "https://lemonade.social/s/celogovernance",
       external: true,
       icon: "img/homepage/contribute.svg",
     },

--- a/snippets/home.jsx
+++ b/snippets/home.jsx
@@ -476,7 +476,7 @@ export const CeloBuilderEcosystem = ({
     {
       title: "Bring Your Ideas to Life",
       desc: "Sign up for upcoming hackathons and workshops",
-      href: "https://celo.lemonade.social/",
+      href: "https://lemonade.social/s/celo",
       external: true,
       icon: "img/homepage/contribute.svg",
     },


### PR DESCRIPTION
## Summary

Several lemonade.social links in the docs pointed to broken or incorrect URLs:

- `lemonade.social/celo` (404, unclaimed username)
- `celo.stand.lemonade.social/events` (404)
- `lemonade.social/s/celo` (wrong space)

All references now point to the correct governance events page: `lemonade.social/s/celogovernance` (200 OK), with labels updated to "Governance Events".

## Files changed

- `home/celo.mdx`
- `home/protocol/governance/governance-toolkit.mdx`
- `contribute-to-celo/builders.mdx`
- `docs.json`
- `snippets/home.jsx`