### PR TITLE
notices: update op-geth deprecation title and add subtitle

### DIFF
--- a/infra-partners/notices/op-geth-deprecation.mdx
+++ b/infra-partners/notices/op-geth-deprecation.mdx
@@ -1,5 +1,6 @@
 ---
-title: "op-geth Deprecation"
+title: "End of Support for op-geth"
+description: "Transition from op-geth to op-reth ahead of the Ethereum Glamsterdam hardfork"
 ---
 
 This notice outlines the deprecation of `op-geth` and the transition to `op-reth` as the supported execution client for Celo. It includes key information for node operators, RPC providers, and bridge operators.


### PR DESCRIPTION
## Summary
- Rename page title from "op-geth Deprecation" to "End of Support for op-geth"
- Add `description` frontmatter as a subtitle: "Transition from op-geth to op-reth ahead of the Ethereum Glamsterdam hardfork"

## Test plan
- [x] Verify the page renders correctly in Mintlify preview with the new title and subtitle
- [x] Confirm the page still appears in the notices nav under the expected entry