### PR TITLE
docs(minipay+fee-abstraction): add USDT 6-decimal warning and USDT celocli transfer example

### DIFF
--- a/build-on-celo/build-on-minipay/code-library.mdx
+++ b/build-on-celo/build-on-minipay/code-library.mdx
@@ -358,6 +358,12 @@ console.log(attestations.accounts);
 
 ## Request an ERC20 token transfer
 
+<Warning>
+  USDT and USDC on Celo use **6 decimals**, not 18. Pass `tokenDecimals` as `6` when
+  transferring either token. Using `18` will send 1,000,000,000,000× more than intended.
+  USDm uses 18 decimals.
+</Warning>
+
 ```js
 import { createWalletClient, createPublicClient, custom, http, encodeFunctionData, parseUnits } from "viem";
 import { celo, celoSepolia } from "viem/chains";
@@ -378,16 +384,16 @@ const publicClient = createPublicClient({
 async function requestTransfer(tokenAddress, transferValue, tokenDecimals, receiverAddress) {
   const hash = await walletClient.sendTransaction({
     to: tokenAddress,
-    // Mainnet addresses:
-    // USDm: '0x765DE816845861e75A25fCA122bb6898B8B1282a'
-    // USDC: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C'
-    // USDT: '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e'
+    // Mainnet token addresses and their decimals:
+    // USDm: '0x765DE816845861e75A25fCA122bb6898B8B1282a'  (18 decimals)
+    // USDC: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C'  (6 decimals)
+    // USDT: '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e'  (6 decimals)
     data: encodeFunctionData({
       abi: stableTokenABI, // Token ABI from @celo/abis
       functionName: "transfer",
       args: [
         receiverAddress,
-        // Different tokens can have different decimals, USDm (18), USDC (6)
+        // USDm uses 18 decimals; USDC and USDT use 6 decimals
         parseUnits(`${Number(transferValue)}`, tokenDecimals),
       ],
     }),

--- a/build-on-celo/fee-abstraction/using-fee-abstraction.mdx
+++ b/build-on-celo/fee-abstraction/using-fee-abstraction.mdx
@@ -65,7 +65,18 @@ celocli transfer:erc20 \
   --privateKey [PRIVATE_KEY]
 ```
 
-When using USDC or USDT, use the adapter address (not the token address) to avoid inaccuracies caused by their 6-decimal precision.
+When using USDC or USDT, use the **adapter address** (not the token address) as `--gasCurrency`. Both tokens use 6 decimals — pass `--value` in units of `10^6` (e.g. `1000000` = 1 USDT/USDC).
+
+Transfer 1 USDT using USDT as the fee currency:
+```bash
+celocli transfer:erc20 \
+  --erc20Address 0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e \
+  --from 0x22ae7Cf4cD59773f058B685a7e6B7E0984C54966 \
+  --to 0xDF7d8B197EB130cF68809730b0D41999A830c4d7 \
+  --value 1000000 \
+  --gasCurrency 0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72 \
+  --privateKey [PRIVATE_KEY]
+```
 
 ---
 


### PR DESCRIPTION
## What changed

**`build-on-celo/build-on-minipay/code-library.mdx`**
- Added a `<Warning>` callout before the `Request an ERC20 token transfer` section explicitly stating that USDT and USDC use 6 decimals on Celo, not 18
- Updated the inline address comment in `requestTransfer` to include the decimal count next to each token address (USDm: 18, USDC: 6, USDT: 6)
- Corrected the `parseUnits` comment from `"USDm (18), USDC (6)"` — which omitted USDT entirely — to `"USDm uses 18 decimals; USDC and USDT use 6 decimals"`

**`build-on-celo/fee-abstraction/using-fee-abstraction.mdx`**
- The CLI section showed a USDC example only. Added an equivalent USDT `celocli transfer:erc20` example using the correct USDT mainnet token address (`0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e`) and its fee adapter address (`0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72`)
- Clarified that `--value` for both USDC and USDT is in units of `10^6`

## Why

The `requestTransfer` snippet listed USDT in the address comment but gave no decimal count for it, while explicitly noting USDC (6). A developer building a USDT transfer and following this example without noticing the omission would likely pass `18` as `tokenDecimals`, sending 1,000,000,000,000× the intended amount. The `<Warning>` and inline comment make the 6-decimal requirement impossible to miss.

The fee-abstraction CLI section documented USDC usage but left USDT as table-only — no runnable example. The USDT adapter address is already in the table above; adding the `celocli` example makes it consistent.

## How to verify

1. In `code-library.mdx`: search for `requestTransfer` — confirm the `<Warning>` block appears above the code fence and the inline comment now reads `(6 decimals)` next to USDT
2. In `using-fee-abstraction.mdx`: search for `48065fbbe` — confirm a complete `celocli` command appears using it as `--erc20Address` and `0e2a3e05` as `--gasCurrency`
3. Token addresses can be verified at [celoscan.io/address/0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e](https://celoscan.io/address/0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e) and [celoscan.io/address/0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72](https://celoscan.io/address/0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72)