### PR TITLE
Rename celopedia URL, add redirects, label as Celopedia (Skill)

### DIFF
--- a/build-on-celo/build-with-ai/8004.mdx
+++ b/build-on-celo/build-with-ai/8004.mdx
@@ -273,5 +273,5 @@ ERC-8004 works seamlessly with Celo's ecosystem:
 ## Related Protocols
 
 - [x402](/build-on-celo/build-with-ai/x402) - Payment layer for AI agents
-- [Celopedia](/build-on-celo/build-with-ai/celo-pedia) - Celo ecosystem knowledge for coding assistants
+- [Celopedia](/build-on-celo/build-with-ai/celopedia) - Celo ecosystem knowledge for coding assistants
 - [MCP Servers](/build-on-celo/build-with-ai/mcp/index) - Connect agents to data and tools

--- a/build-on-celo/build-with-ai/celopedia.mdx
+++ b/build-on-celo/build-with-ai/celopedia.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Celopedia"
-sidebarTitle: "Celopedia"
+sidebarTitle: "Celopedia (Skill)"
 description: "Use Celopedia to query Celo ecosystem data, protocol references, contract addresses, MiniPay guidance, DeFi protocols, grants, and AI agent infrastructure from your coding assistant."
 ---
 

--- a/build-on-celo/build-with-ai/overview.mdx
+++ b/build-on-celo/build-with-ai/overview.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Overview"
 
 Celo is a leading Ethereum Layer 2 optimized for agentic activity with real-world utility, enabling AI agents to autonomously perform onchain actions tied directly to payments, commerce, and financial coordination.
 
-Agents on Celo can tap into the network's expansive payments ecosystem, leveraging fast finality, sub-cent transaction costs, and a stablecoin-optimized financial stack spanning peer-to-peer transfers, merchant payments, remittances, and onchain FX. Combined with native support for AI agent standards like [ERC-8004](/build-on-celo/build-with-ai/8004) and Celo's [Celopedia](/build-on-celo/build-with-ai/celo-pedia), Celo provides a production-ready environment for deploying AI agents that do more than trade tokens—they move money, coordinate economic activity, and interact with real users at global scale.
+Agents on Celo can tap into the network's expansive payments ecosystem, leveraging fast finality, sub-cent transaction costs, and a stablecoin-optimized financial stack spanning peer-to-peer transfers, merchant payments, remittances, and onchain FX. Combined with native support for AI agent standards like [ERC-8004](/build-on-celo/build-with-ai/8004) and Celo's [Celopedia](/build-on-celo/build-with-ai/celopedia), Celo provides a production-ready environment for deploying AI agents that do more than trade tokens—they move money, coordinate economic activity, and interact with real users at global scale.
 
 ## Why Build AI Agents on Celo
 

--- a/build-on-celo/build-with-ai/x402.mdx
+++ b/build-on-celo/build-with-ai/x402.mdx
@@ -336,5 +336,5 @@ app.get("/articles/:id", async (req, res) => {
 ## Related
 
 - [ERC-8004](/build-on-celo/build-with-ai/8004) - Trust layer for AI agents
-- [Celopedia](/build-on-celo/build-with-ai/celo-pedia) - Celo ecosystem knowledge for coding assistants
+- [Celopedia](/build-on-celo/build-with-ai/celopedia) - Celo ecosystem knowledge for coding assistants
 - [Fee Abstraction](/build-on-celo/fee-abstraction/overview) - Pay gas with stablecoins on Celo

--- a/docs.json
+++ b/docs.json
@@ -132,7 +132,7 @@
                 "pages": [
                   "build-on-celo/build-with-ai/8004",
                   "build-on-celo/build-with-ai/x402",
-                  "build-on-celo/build-with-ai/celo-pedia",
+                  "build-on-celo/build-with-ai/celopedia",
                   "build-on-celo/build-with-ai/vibe-coding"
                 ]
               },
@@ -3075,7 +3075,11 @@
     },
     {
       "source": "/build-on-celo/build-with-ai/agent-skills",
-      "destination": "/build-on-celo/build-with-ai/celo-pedia"
+      "destination": "/build-on-celo/build-with-ai/celopedia"
+    },
+    {
+      "source": "/build-on-celo/build-with-ai/celo-pedia",
+      "destination": "/build-on-celo/build-with-ai/celopedia"
     },
     {
       "source": "/tooling/overview/network-overview",

--- a/docs.json
+++ b/docs.json
@@ -3074,6 +3074,10 @@
       "destination": "/build-on-celo/build-with-ai/overview"
     },
     {
+      "source": "/build-on-celo/build-with-ai/agent-skills",
+      "destination": "/build-on-celo/build-with-ai/celo-pedia"
+    },
+    {
       "source": "/tooling/overview/network-overview",
       "destination": "/build-on-celo/network-overview"
     },


### PR DESCRIPTION
## Summary
- Rename `build-on-celo/build-with-ai/celo-pedia.mdx` → `celopedia.mdx` so the URL is `/build-on-celo/build-with-ai/celopedia` (matches the product name, no hyphen)
- Update sidebar label to **Celopedia (Skill)** to disambiguate from other Celopedia references
- Update navigation entry in `docs.json` and all internal links (`8004.mdx`, `x402.mdx`, `overview.mdx`)
- Redirects in `docs.json`:
  - `/build-on-celo/build-with-ai/agent-skills` → `/build-on-celo/build-with-ai/celopedia` (PR #2185 removed this page without a redirect)
  - `/build-on-celo/build-with-ai/celo-pedia` → `/build-on-celo/build-with-ai/celopedia` (covers anyone who hit the hyphenated URL between #2185 and this PR)

## Test plan
- [ ] After deploy, `/build-on-celo/build-with-ai/celopedia` renders the page
- [ ] `/build-on-celo/build-with-ai/celo-pedia` redirects to the new URL
- [ ] `/build-on-celo/build-with-ai/agent-skills` redirects to the new URL
- [ ] Sidebar shows **Celopedia (Skill)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)