### PR TITLE
Add Uniswap v4 Celo Sepolia addresses beside mainnet

### DIFF
--- a/tooling/contracts/uniswap-contracts.mdx
+++ b/tooling/contracts/uniswap-contracts.mdx
@@ -4,22 +4,28 @@ id: uniswap-contracts
 ---
 
 <Info>
-The latest versions of Uniswap v4 and v3 contracts are deployed at the addresses listed below. Integrators should no longer assume that they are deployed to the same addresses across chains and be extremely careful to confirm mappings below.
+The latest versions of Uniswap v4 and v3 contracts are deployed at the addresses listed below, on both Celo mainnet and the Celo Sepolia testnet. Integrators should no longer assume that they are deployed to the same addresses across chains and be extremely careful to confirm mappings below.
 </Info>
 
 ## Uniswap V4 Contracts
 
-Uniswap v4 introduces a new modular architecture with hooks and singleton pool manager design. The core contracts are deployed on Celo mainnet.
+Uniswap v4 introduces a new modular architecture with hooks and singleton pool manager design. The core contracts are deployed on Celo mainnet and on the Celo Sepolia testnet.
 
-| Contract                           | CELO Address                               |
-| ---------------------------------- | ------------------------------------------ |
-| PoolManager                        | [0x288dc841A52FCA2707c6947B3A777c5E56cd87BC](https://celoscan.io/address/0x288dc841A52FCA2707c6947B3A777c5E56cd87BC) |
-| PositionManager                    | [0xf7965f3981e4d5bc383bfbcb61501763e9068ca9](https://celoscan.io/address/0xf7965f3981e4d5bc383bfbcb61501763e9068ca9) |
-| PositionDescriptor                 | [0x5727E22b25fEEe05E8dFa83C752B86F19D102D8A](https://celoscan.io/address/0x5727E22b25fEEe05E8dFa83C752B86F19D102D8A) |
-| V4Quoter                           | [0x28566da1093609182dff2cb2a91cfd72e61d66cd](https://celoscan.io/address/0x28566da1093609182dff2cb2a91cfd72e61d66cd) |
-| StateView                          | [0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb](https://celoscan.io/address/0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb) |
-| UniversalRouter                    | [0xcb695bc5d3aa22cad1e6df07801b061a05a0233a](https://celoscan.io/address/0xcb695bc5d3aa22cad1e6df07801b061a05a0233a) |
-| Permit2                            | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://celoscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
+| Contract                           | CELO Address                               | Celo Sepolia Address                       |
+| ---------------------------------- | ------------------------------------------ | ------------------------------------------ |
+| PoolManager                        | [0x288dc841A52FCA2707c6947B3A777c5E56cd87BC](https://celoscan.io/address/0x288dc841A52FCA2707c6947B3A777c5E56cd87BC) | [0x2af85C83CFe7bC5182F81E5aE82661b4E9F15A1e](https://celo-sepolia.blockscout.com/address/0x2af85C83CFe7bC5182F81E5aE82661b4E9F15A1e) |
+| PositionManager                    | [0xf7965f3981e4d5bc383bfbcb61501763e9068ca9](https://celoscan.io/address/0xf7965f3981e4d5bc383bfbcb61501763e9068ca9) | [0xB104b7c42DAB49d31fe3Ea91Dd80305348Cc37C1](https://celo-sepolia.blockscout.com/address/0xB104b7c42DAB49d31fe3Ea91Dd80305348Cc37C1) |
+| PositionDescriptor                 | [0x5727E22b25fEEe05E8dFa83C752B86F19D102D8A](https://celoscan.io/address/0x5727E22b25fEEe05E8dFa83C752B86F19D102D8A) | [0x3B13783e319Be24E2b9Db588745eA3202723B497](https://celo-sepolia.blockscout.com/address/0x3B13783e319Be24E2b9Db588745eA3202723B497) |
+| V4Quoter                           | [0x28566da1093609182dff2cb2a91cfd72e61d66cd](https://celoscan.io/address/0x28566da1093609182dff2cb2a91cfd72e61d66cd) | [0xca5E523FA87c7dC67762c8E7f4a65783899b3c72](https://celo-sepolia.blockscout.com/address/0xca5E523FA87c7dC67762c8E7f4a65783899b3c72) |
+| StateView                          | [0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb](https://celoscan.io/address/0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb) | [0xF7e0Ba08d608cE1c90498c763e9fa001404e2a4b](https://celo-sepolia.blockscout.com/address/0xF7e0Ba08d608cE1c90498c763e9fa001404e2a4b) |
+| UniversalRouter                    | [0xcb695bc5d3aa22cad1e6df07801b061a05a0233a](https://celoscan.io/address/0xcb695bc5d3aa22cad1e6df07801b061a05a0233a) | [0x8891A0A682cC7f0bda7912E79C80167403d96103](https://celo-sepolia.blockscout.com/address/0x8891A0A682cC7f0bda7912E79C80167403d96103) |
+| Permit2                            | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://celoscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://celo-sepolia.blockscout.com/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
+
+<Note>
+On Celo Sepolia the `UniversalRouter` and `PositionManager` use the CELO ERC-20 (`0x471EcE3750Da237f93B8E339c536989b8978a438`) as their wrapped-native (`weth9`) slot, matching Celo mainnet. CELO does not implement `deposit()` / `withdraw()` on the L2, so the router's `WRAP_ETH` / `UNWRAP_WETH` commands will revert. Pools using the native asset (`address(0)`) or CELO as an ERC-20 are unaffected.
+
+Two test routers (`PoolSwapTest` at [0x42592B9fFA3be9351cf06EC499e28b88a4A99f50](https://celo-sepolia.blockscout.com/address/0x42592B9fFA3be9351cf06EC499e28b88a4A99f50), `PoolModifyLiquidityTest` at [0x643ddc282cD4C65a40cd96c27968B63a2e31cF6d](https://celo-sepolia.blockscout.com/address/0x643ddc282cD4C65a40cd96c27968B63a2e31cF6d)) are also deployed on Celo Sepolia for convenience.
+</Note>
 
 ## Uniswap V3 Contracts
 


### PR DESCRIPTION
## What

Adds the **Uniswap v4** contract addresses for the **Celo Sepolia** testnet (chain `11142220`) to `tooling/contracts/uniswap-contracts.mdx`, alongside the existing Celo mainnet column.

The full v4 stack is now deployed and **verified on Blockscout** ([celo-sepolia.blockscout.com](https://celo-sepolia.blockscout.com)), built from the same pinned sources as Celo mainnet (v4-core `v4.0.0`, v4-periphery `363226d`, universal-router `020e1b7`).

## Changes

- New **"Celo Sepolia Address"** column in the V4 contracts table (PoolManager, PositionManager, PositionDescriptor, V4Quoter, StateView, UniversalRouter, Permit2), with Blockscout links.
- A `<Note>` documenting that the `weth9` slot points at the CELO ERC-20 (matching mainnet) — so UniversalRouter `WRAP_ETH`/`UNWRAP_WETH` revert on the L2, while native and CELO-as-ERC-20 pools work fully — plus the two testnet helper routers (`PoolSwapTest`, `PoolModifyLiquidityTest`).
- Updated the intro note to mention testnet availability.

## Why

Teams (e.g. Boundless) need v4 on the testnet to run their test suites before deploying against mainnet. Documenting the addresses beside mainnet makes the testnet deployment discoverable.

## Verification

All Sepolia addresses cross-checked against the live deployment, and all contracts show as verified on Blockscout. Three demo pools (native/TKA, TKA/TKB, TKC/TKA) are seeded with liquidity on-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)