### PR TITLE
Add Openfort to Wallet Infrastructure

### DIFF
--- a/tooling/wallets/index.mdx
+++ b/tooling/wallets/index.mdx
@@ -74,6 +74,16 @@ Privy makes it easy to build on crypto rails. Securely spin up whitelabel wallet
 
 ---
 
+### [Openfort](https://www.openfort.io/)
+
+Openfort is wallet infrastructure for developers. Spin up non-custodial embedded wallets with social login, programmable backend (server) wallets for automation, and account abstraction with paymasters for gasless transactions and paying fees in stablecoins.
+
+- Homepage: [openfort.io](https://www.openfort.io/)
+- [Docs](https://www.openfort.io/docs)
+- [Source Code](https://github.com/openfort-xyz)
+
+---
+
 ### [Alchemy Smart Wallets](https://www.alchemy.com/smart-wallets)
 
 Onboard and activate users with secure, easy-to-use, enterprise-grade wallets. No seed phrase or gas required.


### PR DESCRIPTION
## Description

Adds [Openfort](https://www.openfort.io/) to the **Wallet Infrastructure** section of `tooling/wallets/index.mdx`, alongside Privy, Para, Portal, and thirdweb.

Openfort is wallet infrastructure for developers, offering non-custodial embedded wallets with social login, programmable backend (server) wallets, and account abstraction with paymasters for gasless transactions and paying fees in stablecoins — all relevant to building on Celo.

### Entry added

- Homepage: https://www.openfort.io/
- Docs: https://www.openfort.io/docs
- Source Code: https://github.com/openfort-xyz

## Changes

- `tooling/wallets/index.mdx` — new Openfort entry under "Wallet Infrastructure" matching the existing format.