### PR TITLE
Fix stale validation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ mint dev
 
 - **Dev environment not running:** Run `mint update` to ensure you have the most recent version of the CLI
 - **Page loads as 404:** Make sure you are running in a folder with a valid `docs.json`
-- **Validation fails:** Run `./scripts/validate-docs.sh` and review the output for specific errors
+- **Validation fails:** Run `mint broken-links` and review the output for specific errors
 - **Broken links detected:** Review the validation output and fix referenced files or URLs
 
 ### Resources


### PR DESCRIPTION
The troubleshooting section in the README pointed at `./scripts/validate-docs.sh`, which doesn't exist in the repo. Point it at `mint broken-links` instead — the same command used in the docs-validation CI workflow and referenced earlier in the README's Contributing section.

## Test plan
- N/A (docs-only one-line change)