### PR TITLE
Add op-reth migration dates

### DIFF
--- a/infra-partners/notices/op-geth-deprecation.mdx
+++ b/infra-partners/notices/op-geth-deprecation.mdx
@@ -1,25 +1,30 @@
 ---
 title: "End of Support for op-geth"
-description: "Transition from op-geth to op-reth ahead of the Ethereum Glamsterdam hardfork"
+description: "Transition from op-geth to op-reth as Celo's supported execution client"
 ---
 
 This notice outlines the deprecation of `op-geth` and the transition to `op-reth` as the supported execution client for Celo. It includes key information for node operators, RPC providers, and bridge operators.
 
-`op-geth` will not support the upcoming Ethereum Glamsterdam hardfork. All node operators must migrate to `op-reth` before this upgrade to remain in sync with the canonical chain.
+Celo is switching its execution client from `op-geth` to `op-reth`. All node operators must migrate to `op-reth` by the switch date for their network to remain in sync with the canonical chain.
 
-We will share exact dates once the Ethereum Glamsterdam timeline is finalized.
+<Note>
+**Switch dates**
+
+- **Celo Sepolia**: June 24, 2026
+- **Mainnet**: late July 2026
+</Note>
 
 ## Summary Of Changes
 
 Following [Optimism's](https://docs.optimism.io/notices/op-geth-deprecation) deprecation of op-geth, Celo will also discontinue support for `op-geth` and adopt `op-reth` as the primary execution client.
 
-- **`op-geth`**: Supported only until the Ethereum Glamsterdam hardfork. After this, it will no longer be compatible with the network. 
+- **`op-geth`**: Supported only until the switch date for each network. After that, it will no longer be compatible with the network.
 - **`op-reth`**: The new supported execution client built on `reth`.
 - **`op-node`**: No changes. It remains fully supported.
 
 ## Requirements for Node Operators
 
-Node operators must complete migration to `op-reth` before the Ethereum Glamsterdam hardfork.
+Node operators must complete migration to `op-reth` by the switch date for their network (see above).
 
 A Celo-compatible `op-reth` release and migration guide will be published shortly. In the meantime:
 

--- a/infra-partners/notices/op-geth-deprecation.mdx
+++ b/infra-partners/notices/op-geth-deprecation.mdx
@@ -7,12 +7,10 @@ This notice outlines the deprecation of `op-geth` and the transition to `op-reth
 
 Celo is switching its execution client from `op-geth` to `op-reth`. All node operators must migrate to `op-reth` by the switch date for their network to remain in sync with the canonical chain.
 
-<Note>
-**Switch dates**
+## Switch dates
 
 - **Celo Sepolia**: June 24, 2026
 - **Mainnet**: late July 2026
-</Note>
 
 ## Summary Of Changes
 

--- a/infra-partners/notices/overview.mdx
+++ b/infra-partners/notices/overview.mdx
@@ -6,7 +6,7 @@ description: "Active upgrade notices, deprecations, and network change announcem
 
 <CardGroup cols={1}>
   <Card title="End of Support for op-geth" icon="circle-xmark" href="/infra-partners/notices/op-geth-deprecation">
-    Transition from op-geth to op-reth ahead of the Ethereum Glamsterdam hardfork.
+    Transition from op-geth to op-reth as Celo's supported execution client.
   </Card>
   <Card title="Deprecation of Req/Res CL P2P Sync" icon="triangle-exclamation" href="/infra-partners/notices/req-resp-cl-sync-deprecation">
     The op-node Req/Res consensus-layer P2P sync client is deprecated in favor of execution-layer syncing.

--- a/infra-partners/operators/archive-node.mdx
+++ b/infra-partners/operators/archive-node.mdx
@@ -12,7 +12,7 @@ This guide covers running a **full archive node**, which serves every historical
 <Warning>
 **op-geth is being deprecated**
 
-These instructions use `op-geth`, which is supported only until the Ethereum Glamsterdam hardfork. Celo is transitioning to `op-reth` as the primary execution client. See [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation) for the migration timeline; archive-node guidance for `op-reth` will follow once a Celo-compatible release is published.
+These instructions use `op-geth`, which is supported only until your network's switch to `op-reth`. Celo is transitioning to `op-reth` as the primary execution client. See [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation) for the switch dates; archive-node guidance for `op-reth` will follow once a Celo-compatible release is published.
 </Warning>
 
 ## Overview

--- a/infra-partners/operators/configuration.mdx
+++ b/infra-partners/operators/configuration.mdx
@@ -8,7 +8,7 @@ This page documents the `.env` variables and the key client flags used by the [c
 <Warning>
 **op-geth is being deprecated**
 
-The variables below configure `op-geth`, the execution client used today. Celo is transitioning to `op-reth` as the primary execution client ahead of the Ethereum Glamsterdam hardfork. See [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation); `op-reth` configuration will be documented once a Celo-compatible release ships.
+The variables below configure `op-geth`, the execution client used today. Celo is transitioning to `op-reth` as the primary execution client. See [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation) for the switch dates; `op-reth` configuration will be documented once a Celo-compatible release ships.
 </Warning>
 
 ## Node type and sync mode

--- a/infra-partners/operators/maintenance.mdx
+++ b/infra-partners/operators/maintenance.mdx
@@ -20,7 +20,7 @@ This pulls the latest changes from GitHub and the latest images from the registr
 <Warning>
 **Hardfork upgrades are time-sensitive**
 
-Network hardforks require running a compatible client version *before* the fork block, or your node will stop following the chain. Watch the [Notices](/infra-partners/notices/archive/l2-migration) for each upgrade's required versions and timing. The next major required migration is the move from op-geth to op-reth ahead of the Ethereum Glamsterdam hardfork — see [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation).
+Network hardforks require running a compatible client version *before* the fork block, or your node will stop following the chain. Watch the [Notices](/infra-partners/notices/archive/l2-migration) for each upgrade's required versions and timing. The next major required migration is the move from op-geth to op-reth — see [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation).
 </Warning>
 
 To pin a specific image version instead of tracking the latest, set the matching `IMAGE_TAG__*` variable in your `.env` (for example `IMAGE_TAG__OP_GETH` or `IMAGE_TAG__OP_NODE`).

--- a/infra-partners/operators/overview.mdx
+++ b/infra-partners/operators/overview.mdx
@@ -23,12 +23,12 @@ See [Architecture](/infra-partners/operators/architecture) for how these fit tog
 ## Execution client
 
 - **op-reth** — the execution client Celo is adopting as the primary client going forward, built on `reth`. A Celo-compatible release and migration guide are coming.
-- **op-geth** — the execution client used today. It is being deprecated ahead of the Ethereum Glamsterdam hardfork but remains fully supported until then. All current guides use `op-geth`.
+- **op-geth** — the execution client used today. It is being deprecated in favor of `op-reth` and remains fully supported until your network's switch date. All current guides use `op-geth`.
 
 <Warning>
 **op-geth is being deprecated**
 
-`op-geth` will not support the Ethereum Glamsterdam hardfork. All node operators must migrate to `op-reth` before that upgrade. See [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation) for details and follow the [celo-l2-node-docker-compose](https://github.com/celo-org/celo-l2-node-docker-compose) repository for release updates.
+Celo is switching its execution client from `op-geth` to `op-reth`. All node operators must migrate to `op-reth` by their network's switch date. See [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation) for the switch dates and details, and follow the [celo-l2-node-docker-compose](https://github.com/celo-org/celo-l2-node-docker-compose) repository for release updates.
 </Warning>
 
 ## Guides

--- a/infra-partners/operators/run-node.mdx
+++ b/infra-partners/operators/run-node.mdx
@@ -14,7 +14,7 @@ If you wish to migrate data from a Celo L1 node and have not yet done so, please
 <Info>
 **Execution client: op-geth today, op-reth next**
 
-These instructions use `op-geth`. Celo is transitioning to `op-reth` as the primary execution client ahead of the Ethereum Glamsterdam hardfork; `op-geth` remains fully supported until then. See [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation) for the transition timeline.
+These instructions use `op-geth`. Celo is transitioning to `op-reth` as the primary execution client; `op-geth` remains fully supported until your network's switch date. See [End of Support for op-geth](/infra-partners/notices/op-geth-deprecation) for the switch dates.
 </Info>
 
 ## Recommended Hardware


### PR DESCRIPTION
## What

The op-geth → op-reth migration is driven by Celo, not the Ethereum Glamsterdam hardfork. This updates the node operator docs accordingly.

- Add per-network switch dates to the deprecation notice:
  - **Celo Sepolia**: June 24, 2026
  - **Mainnet**: late July 2026
- Remove all Glamsterdam references and "dates TBD" language across the notice and operator guides.

The dates live only in `op-geth-deprecation.mdx`; every other mention points there (single source of truth).

## Files

- `infra-partners/notices/op-geth-deprecation.mdx` — switch-date `<Note>` block, reworded summary/requirements
- `infra-partners/notices/overview.mdx` — card subtitle
- `infra-partners/operators/{overview,run-node,configuration,archive-node,maintenance}.mdx` — Glamsterdam stripped, repointed to the notice
