### PR TITLE
docs: use X-PAYMENT header consistently in x402 Next.js example

### DIFF
--- a/build-on-celo/build-with-ai/x402.mdx
+++ b/build-on-celo/build-with-ai/x402.mdx
@@ -142,9 +142,7 @@ const thirdwebFacilitator = facilitator({
 });
 
 export async function GET(request: Request) {
-  const paymentData =
-    request.headers.get("PAYMENT-SIGNATURE") ||
-    request.headers.get("X-PAYMENT");
+  const paymentData = request.headers.get("X-PAYMENT");
 
   const result = await settlePayment({
     resourceUrl: "https://your-api.com/premium-content",


### PR DESCRIPTION
The PAYMENT-SIGNATURE fallback is not part of the x402 spec.  The protocol uses only X-PAYMENT. Simplified to one consistent header.