### PR TITLE
docs: combine x402 X-PAYMENT fix (#2203) and Openfort wallet entry (#2199)

### DIFF
--- a/build-on-celo/build-with-ai/x402.mdx
+++ b/build-on-celo/build-with-ai/x402.mdx
@@ -142,9 +142,7 @@ const thirdwebFacilitator = facilitator({
 });
 
 export async function GET(request: Request) {
-  const paymentData =
-    request.headers.get("PAYMENT-SIGNATURE") ||
-    request.headers.get("X-PAYMENT");
+  const paymentData = request.headers.get("X-PAYMENT");
 
   const result = await settlePayment({
     resourceUrl: "https://your-api.com/premium-content",

--- a/tooling/wallets/index.mdx
+++ b/tooling/wallets/index.mdx
@@ -74,6 +74,16 @@ Privy makes it easy to build on crypto rails. Securely spin up whitelabel wallet
 
 ---
 
+### [Openfort](https://www.openfort.io/)
+
+Openfort is wallet infrastructure for developers. Spin up non-custodial embedded wallets with social login, programmable backend (server) wallets for automation, and account abstraction with paymasters for gasless transactions and paying fees in stablecoins.
+
+- Homepage: [openfort.io](https://www.openfort.io/)
+- [Docs](https://www.openfort.io/docs)
+- [Source Code](https://github.com/openfort-xyz)
+
+---
+
 ### [Alchemy Smart Wallets](https://www.alchemy.com/smart-wallets)
 
 Onboard and activate users with secure, easy-to-use, enterprise-grade wallets. No seed phrase or gas required.


### PR DESCRIPTION
Combines two open doc PRs into one. Closes #2203 and closes #2199.

## Changes

- **`build-on-celo/build-with-ai/x402.mdx`** (from #2203, by @2TheMoom): Drop the non-spec `PAYMENT-SIGNATURE` header fallback in the x402 Next.js example and use only `X-PAYMENT`, matching the x402 spec.
- **`tooling/wallets/index.mdx`** (from #2199, by @joalavedra): Add an Openfort entry under Wallet Infrastructure — non-custodial embedded wallets, programmable backend wallets, and account abstraction with paymasters.

The two source PRs touch different files and were cherry-picked here unchanged, preserving original authorship.