### PR TITLE
fix: repair broken RPC providers links on Network Information page

### DIFF
--- a/build-on-celo/network-overview.mdx
+++ b/build-on-celo/network-overview.mdx
@@ -15,7 +15,7 @@ Overview of Celo Mainnet and the Celo Sepolia Testnet.
 | Description                | The production Celo network                                                                                                                                                                               |
 | Chain ID                   | 42220                                                                                                                                                                                                     |
 | Currency Symbol            | CELO                                                                                                                                                                                                      |
-| RPC Nodes                  | <ul><li>[List of RPC providers](network/node/overview#as-a-service)</li><li>[Celo L2 Mainnet Day 1 Node and RPC providers](/developer#node-and-rpc-providers)</li></ul> |
+| RPC Nodes                  | [List of RPC providers](/tooling/nodes/overview#as-a-service)                                                                                                                                            |
 | RPC Endpoint (best effort) | https://forno.celo.org <br/> Note: [Forno](/tooling/nodes/forno#celo-mainnet) is rate limited, as your usage increases consider options that can provide the desired level of support (SLA).                          |
 | Block Explorers            | <ul><li>[https://explorer.celo.org](https://explorer.celo.org)</li><li>[https://celoscan.io](https://celoscan.io)</li></ul>                                                                               |
 | Bridge Link                | [List of bridges](/developer/bridges/bridges)                                                                                                                                                             |
@@ -30,6 +30,7 @@ Overview of Celo Mainnet and the Celo Sepolia Testnet.
 | Description                | The New Developer Testnet network (replacing Alfajores)                                                                                                  |
 | Chain ID                   | 11142220                                                                                                                                                 |
 | Currency Symbol            | CELO                                                                                                                                                     |
+| RPC Nodes                  | [List of RPC providers](/tooling/nodes/overview#as-a-service)                                                                                            |
 | RPC Endpoint (best effort) | [https://forno.celo-sepolia.celo-testnet.org](https://forno.celo-sepolia.celo-testnet.org)                                                               |
 | OP-Node RPC Endpoint (best effort) | [https://op.celo-sepolia.celo-testnet.org](https://op.celo-sepolia.celo-testnet.org)                                                               |
 | Block Explorer             | [https://celo-sepolia.blockscout.com](https://celo-sepolia.blockscout.com)                                                                             |


### PR DESCRIPTION
## Problem

The **"List of RPC providers"** link on `docs.celo.org/build-on-celo/network-overview` was landing on a Mintlify fallback page. The providers list was never removed — it still lives on the **"Nodes and Services"** page (`/tooling/nodes/overview`) under the **"As a Service"** section, which lists ~15 providers (Alchemy, Ankr, dRPC, Infura, QuickNode, thirdweb, All That Node, GetBlock, etc.).

The link simply had a bad path: it was written as `network/node/overview#as-a-service` **without a leading slash**, so Mintlify resolved it relative to the current page as `/build-on-celo/network/node/overview` (which doesn't exist) and fell back.

## Changes

In `build-on-celo/network-overview.mdx`:

1. **Celo Mainnet table:** repoint `List of RPC providers` to the canonical absolute path `/tooling/nodes/overview#as-a-service`, and remove the stale second item (`/developer#node-and-rpc-providers`) whose anchor no longer exists.
2. **Celo Sepolia Testnet table:** add an `RPC Nodes` row linking to the same providers list — it previously had no providers link at all, only the direct Forno endpoint. Many listed providers support Celo Sepolia.

## Verification

Run the docs locally (`mint dev`), open `/build-on-celo/network-overview`, and click "List of RPC providers" in both the Mainnet and Sepolia tables — each should scroll to the **As a Service** section instead of the fallback page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)