### PR TITLE
Add Ripio stablecoins to local stablecoin list

### DIFF
--- a/build-on-celo/build-with-local-stablecoin.mdx
+++ b/build-on-celo/build-with-local-stablecoin.mdx
@@ -5,7 +5,7 @@ og:description: An overview of all stablecoins on Celo
 
 ### Celo Stablecoin Ecosystem  
 
-Celo supports a diverse range of fiat-referenced stablecoins designed for different regions and use cases, 6 USD-pegged and 20 regional currency-pegged stablecoins. The table below outlines their issuers and contract addresses across Celo Mainnet and Celo Sepolia.
+Celo supports a diverse range of fiat-referenced stablecoins designed for different regions and use cases, 6 USD-pegged and 26 regional currency-pegged stablecoins. The table below outlines their issuers and contract addresses across Celo Mainnet and Celo Sepolia.
 
 | Stablecoin       | Issuer                                                                  | Use Case                                          |Contract Address Mainnet|Contract Address Celo Sepolia Testnet|
 | ---------------- | ----------------------------------------------------------------------- | ------------------------------------------------- |-------------|---------|
@@ -35,4 +35,10 @@ Celo supports a diverse range of fiat-referenced stablecoins designed for differ
 | **USDGLO**       | [Glo Foundation](https://www.glodollar.org/)                            | Impact-driven stablecoin supporting global causes | [0x4f604735c1cf31399c6e711d5962b2b3e0225ad3](https://celoscan.io/address/0x4f604735c1cf31399c6e711d5962b2b3e0225ad3)  | -  |
 | **BRLA Digital** | [BRLA](https://brla.digital/)                                           | Brazil-based stablecoin                           | [0xfecb3f7c54e2caae9dc6ac9060a822d47e053760](https://celoscan.io/token/0xfecb3f7c54e2caae9dc6ac9060a822d47e053760)  |  - |
 | **COPM**         | [Minteo](https://minteo.com/)                                           | Fiat-backed Colombian Peso Stablecoin             |  [0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606](https://celoscan.io/token/0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606) | -  |
+| **wARS**         | [Ripio](https://ripio.com/)                                             | Argentine Peso-pegged stablecoin                  | [0x0dc4f92879b7670e5f4e4e6e3c801d229129d90d](https://celoscan.io/token/0x0dc4f92879b7670e5f4e4e6e3c801d229129d90d)  | -  |
+| **wBRL**         | [Ripio](https://ripio.com/)                                             | Brazilian Real-pegged stablecoin                  | [0xd76f5faf6888e24d9f04bf92a0c8b921fe4390e0](https://celoscan.io/token/0xd76f5faf6888e24d9f04bf92a0c8b921fe4390e0)  | -  |
+| **wMXN**         | [Ripio](https://ripio.com/)                                             | Mexican Peso-pegged stablecoin                    | [0x337e7456b420bd3481e7fa61fa9850343d610d34](https://celoscan.io/token/0x337e7456b420bd3481e7fa61fa9850343d610d34)  | -  |
+| **wCOP**         | [Ripio](https://ripio.com/)                                             | Colombian Peso-pegged stablecoin                  | [0x8a1d45e102e886510e891d2ec656a708991e2d76](https://celoscan.io/token/0x8a1d45e102e886510e891d2ec656a708991e2d76)  | -  |
+| **wPEN**         | [Ripio](https://ripio.com/)                                             | Peruvian Sol-pegged stablecoin                    | [0x4F34c8b3b5FB6D98Da888F0feA543d4d9C9F2eBE](https://celoscan.io/token/0x4F34c8b3b5FB6D98Da888F0feA543d4d9C9F2eBE)  | -  |
+| **wCLP**         | [Ripio](https://ripio.com/)                                             | Chilean Peso-pegged stablecoin                    | [0x61D450a098b6a7f69fC4b98CE68198fe59768651](https://celoscan.io/token/0x61D450a098b6a7f69fC4b98CE68198fe59768651)  | -  |
 | **G$**           | [GoodDollar](https://www.gooddollar.org/)                               | UBI-focused stablecoin for financial inclusion    | [0x62b8b11039fcfe5ab0c56e502b1c372a3d2a9c7a](https://celoscan.io/token/0x62b8b11039fcfe5ab0c56e502b1c372a3d2a9c7a)  | -  |


### PR DESCRIPTION
Adds Ripio's six regional stablecoins — wARS, wBRL, wMXN, wCOP, wPEN, and wCLP — to the Build with Local Stablecoins table in `build-on-celo/build-with-local-stablecoin.mdx`. Each row uses Celoscan token links, consistent with the other third-party issuer entries, and the intro's regional stablecoin count is updated from 20 to 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)