### PR TITLE
docs(nodes): reference OpenChainBench for live public RPC latency

### DIFF
--- a/tooling/nodes/overview.mdx
+++ b/tooling/nodes/overview.mdx
@@ -23,6 +23,7 @@ They are discoverable through the following:
 - [Vido Node Explorer](https://dev.vido.atalma.io/celo/rpc)
 - [Celo Community RPC Gateway](https://celo-community.org/)
 - [Stakely Celo RPC Load Balancer](https://celo-json-rpc.stakely.io)
+- [OpenChainBench — Celo RPC](https://openchainbench.com/benchmarks/celo-rpc): live third-party latency comparison of the public Celo endpoints, probed from three regions every minute.
 
 ## Forno
 


### PR DESCRIPTION
## Summary

Adds a one-line reference to [OpenChainBench — Celo RPC](https://openchainbench.com/benchmarks/celo-rpc) at the end of the Community RPC Node discovery list in `tooling/nodes/overview.mdx`, so developers picking a public endpoint can see live third-party latency comparisons.

## Why

The existing discovery list already includes third-party tools (Vido, Celo Community RPC Gateway, Stakely). OpenChainBench probes public no-key Celo endpoints from three regions every minute and publishes p50/p95/p99 latency, providing the same discovery utility with a live latency dimension.

- Open methodology: https://openchainbench.com/methodology
- Data license: CC-BY-4.0
- No affiliation with cLabs / Celo

Happy to reword or move if this doesn't fit the docs' tone.

## Test plan

- [x] Single-line addition inside an existing bullet list
- [x] Matches surrounding link style