### PR TITLE
Sync MiniPay docs with the MiniPay source of truth

### DIFF
--- a/build-on-celo/build-on-minipay/code-library.mdx
+++ b/build-on-celo/build-on-minipay/code-library.mdx
@@ -387,7 +387,7 @@ async function requestTransfer(tokenAddress, transferValue, tokenDecimals, recei
     // Mainnet token addresses and their decimals:
     // USDm: '0x765DE816845861e75A25fCA122bb6898B8B1282a'  (18 decimals)
     // USDC: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C'  (6 decimals)
-    // USDT: '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e'  (6 decimals)
+    // USDT: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e'  (6 decimals)
     data: encodeFunctionData({
       abi: stableTokenABI, // Token ABI from @celo/abis
       functionName: "transfer",

--- a/build-on-celo/build-on-minipay/deeplinks.mdx
+++ b/build-on-celo/build-on-minipay/deeplinks.mdx
@@ -1,13 +1,34 @@
 ---
 title: MiniPay Deeplinks
-og:description: Special links that open up a relevant MiniPay screen based on intent
+og:description: Special links that open a relevant MiniPay screen based on intent
 ---
 
-## Trigger add cash screen
+Deeplinks let your Mini App interact with MiniPay's native features without manual navigation. They use the host `link.minipay.xyz` and can be triggered from external apps or from within MiniPay itself.
 
-To trigger or redirect a MiniPay user to the add cash screen inside Minipay you can use the following link:
+<Note>
+  The user must have MiniPay installed and be logged in. Users without the app
+  are shown an install prompt.
+</Note>
 
-[https://minipay.opera.com/add_cash](https://minipay.opera.com/add_cash)
+## Available deeplinks
+
+| Action | Deeplink | Description |
+| --- | --- | --- |
+| Add cash | `https://link.minipay.xyz/add_cash` | Launches the add cash flow. Optionally scope the tokens with `?tokens=USDM,USDT` (supported: `USDM`, `USDT`, `USDC`). |
+| Open Mini App | `https://link.minipay.xyz/browse?url=xxx` | Opens an approved Mini App at the given URL. |
+| Discover tab | `https://link.minipay.xyz/discover` | Opens the Mini Apps discovery page. |
+| Transaction receipt | `https://link.minipay.xyz/receipt?tx=xxx` | Shows the receipt for a transaction hash. Append `&celebrate` for a celebration animation. |
+| QR code | `https://link.minipay.xyz/qr` | Shows the user's QR code. |
+| Invite friends | `https://link.minipay.xyz/invite_friends` | Opens the invite friends screen. |
+| Pockets | `https://link.minipay.xyz/balance` | Opens the balance (pockets) view. |
+
+## Trigger the add cash screen
+
+To trigger or redirect a MiniPay user to the add cash screen inside MiniPay, use the following link:
+
+[https://link.minipay.xyz/add_cash](https://link.minipay.xyz/add_cash)
+
+To pre-select which tokens the user can add, pass the `tokens` query parameter, for example [https://link.minipay.xyz/add_cash?tokens=USDM,USDT](https://link.minipay.xyz/add_cash?tokens=USDM,USDT).
 
 <Frame>
 ![add cash minipay deeplink](/img/developer/build-on-minipay/deeplinks/add-cash-deeplink.gif)

--- a/build-on-celo/build-on-minipay/quickstart.mdx
+++ b/build-on-celo/build-on-minipay/quickstart.mdx
@@ -255,8 +255,8 @@ export default function Header() {
 - Always verify the existence of `window.provider` before initializing your web3 library to ensure seamless compatibility with the MiniPay wallet.
 - When using `ngrok`, remember that the tunneling URL is temporary. You'll get a new URL every time you restart ngrok.
 - Be cautious about exposing sensitive information or functionality when using public tunneling services like ngrok. Always use them in a controlled environment.
-- MiniPay currently supports setting the `feeCurrency` property when running `eth_sendTransaction`. However, currency support is limited to `USDm`. More currencies might be supported in future.
-- MiniPay only accepts legacy transactions at the moment. EIP-1559 properties won't be considered when handling requests.
+- MiniPay manages gas fees for you. You can set the `feeCurrency` property when running `eth_sendTransaction`, but MiniPay may ignore it and pay gas in the stablecoin the user holds the most of. Supported gas tokens include `USDT`, `USDC`, and `USDm` (as well as other Mento stablecoins).
+- Use viem or wagmi to build and send transactions, as they provide native support for Celo's fee-currency transactions.
 
 ## Testing Local Development with MiniPay
 


### PR DESCRIPTION
Aligns the `build-on-minipay` docs with the official MiniPay docs (docs.minipay.xyz), which the MiniPay team maintains as the source of truth. Rewrites the deeplinks page to use the current `link.minipay.xyz` host and document all seven deeplinks (add cash, browse, discover, receipt, QR, invite friends, pockets) instead of only the retired `minipay.opera.com/add_cash` link. Corrects the quickstart's stale fee-currency note (MiniPay may ignore `feeCurrency` and pay gas in the user's most-held stablecoin) and drops the outdated legacy-transaction-only claim. Also checksum-normalizes the USDT mainnet address in the code library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)