### PR TITLE
Update banner to promote DeFAI hackathon

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -20,7 +20,7 @@
     "default": "dark"
   },
   "banner": {
-    "content": "⚡️ **Proof of Ship** | Our monthly builder program is back! [Submit your project](https://talent.app/~/earn/celo-proof-of-ship)",
+    "content": "⚡️ **Agentic Payments & DeFAI Hackathon** | Build the future of onchain AI on Celo. [Join the hackathon](https://celoplatform.notion.site/Agentic-Payments-DeFAI-Hackathon-364d5cb803de800c9502d8a384716324)",
     "dismissible": true
   },
   "fonts": {


### PR DESCRIPTION
Swaps the site banner from Proof of Ship to the Agentic Payments & DeFAI Hackathon.

## Changes
- Updated `docs.json` banner content and CTA link to point to the [DeFAI Hackathon](https://celoplatform.notion.site/Agentic-Payments-DeFAI-Hackathon-364d5cb803de800c9502d8a384716324)

🤖 Generated with [Claude Code](https://claude.com/claude-code)