### PR TITLE
docs: "Add to wallet" buttons + route get-started CTAs to Celopedia

### DIFF
--- a/build-on-celo/build-with-ai/celopedia.mdx
+++ b/build-on-celo/build-with-ai/celopedia.mdx
@@ -1,79 +1,64 @@
 ---
 title: "Celopedia"
 sidebarTitle: "Celopedia (Skill)"
-description: "Use Celopedia to query Celo ecosystem data, protocol references, contract addresses, MiniPay guidance, DeFi protocols, grants, and AI agent infrastructure from your coding assistant."
+og:description: "Celopedia gives your AI coding assistant deep Celo knowledge — so you can find an idea, shape it, get feedback, and ship on Celo without leaving your editor."
 ---
 
-Celopedia is a builder-focused knowledge skill for Celo. It packages Celo ecosystem intelligence, protocol references, verified contract addresses, MiniPay guidance, DeFi protocol context, grant information, and AI agent infrastructure into a skill that coding assistants can use while you build.
+**Your AI coding assistant, now fluent in Celo.** Celopedia is a knowledge skill that plugs verified Celo intelligence — contract addresses, protocols, MiniPay, grants, and agent infrastructure — straight into the tools you already build with.
 
-Use it when you want your AI coding agent to answer Celo-specific questions, compare ecosystem opportunities, find contract addresses, scaffold common development patterns, or reason about MiniPay, DeFi, stablecoins, governance, and agentic applications on Celo.
+Go from "what should I build?" to a live dApp without tab-hopping through docs.
 
-## What you can do with Celopedia
+<CardGroup cols={2}>
+  <Card title="Find your idea" icon="lightbulb">
+    Search live ecosystem data to spot the gaps and opportunities worth building.
+  </Card>
+  <Card title="Shape your idea" icon="compass-drafting">
+    Compare verticals, pick the right protocols, and scope an architecture that fits Celo.
+  </Card>
+  <Card title="Get feedback" icon="comments">
+    Pressure-test as you go — how saturated is this market, how does my approach compare?
+  </Card>
+  <Card title="Go live fast" icon="rocket">
+    Grab contract addresses, MiniPay and fee-abstraction patterns, and deploy — all in your editor.
+  </Card>
+</CardGroup>
 
-- **Research ecosystem opportunities**: Search ecosystem data, compare verticals, and identify gaps before you build.
-- **Find contract addresses**: Look up verified addresses for core protocol contracts, Mento stablecoins, Uniswap, Aave, Morpho, bridge contracts, and more.
-- **Build MiniPay apps**: Get MiniPay wallet detection, payment, testing, and submission guidance.
-- **Integrate DeFi protocols**: Ask for Celo-specific patterns for protocols such as Uniswap, Aave, Morpho, Mento, Velodrome, Curve, Ubeswap, and stCELO.
-- **Explore grants and funding**: Match a project idea to relevant Celo grant programs and builder support options.
-- **Build AI agents on Celo**: Use references for ERC-8004, x402, the Celo MCP Server, and agent skills.
+## Install Celopedia
 
-## Install
-
-Install Celopedia with `npx skills`:
+Add it to your coding assistant with one command:
 
 ```bash
 npx skills add celo-org/celopedia-skills
 ```
 
-After installing, restart your coding assistant if it does not discover new skills during an active session.
-
 <Note>
-  Celopedia supports agent environments that use file-based skills, including Codex, Claude Code, and OpenClaw. See the GitHub repository for tool-specific install notes.
+  Restart your coding assistant afterward if it doesn't discover new skills mid-session. Celopedia works with file-based skill environments including Codex, Claude Code, and OpenClaw — see the [GitHub repository](https://github.com/celo-org/celopedia-skills) for tool-specific install notes.
 </Note>
 
-## Example prompts
+## Try it
 
-Once installed, ask your coding assistant questions like:
-
-```text
-What lending protocols exist on Celo?
-```
+Once installed, ask your assistant things like:
 
 ```text
+What lending protocols exist on Celo, and which vertical is least saturated?
 Give me the Uniswap V4 contract addresses on Celo mainnet.
-```
-
-```text
-I want to build a payments Mini App. Show me the recommended architecture.
-```
-
-```text
-What grants can I apply to for a DeFi project on Celo?
-```
-
-```text
+Scaffold a payments Mini App with the recommended architecture.
 Set up a Foundry project for Celo with fee abstraction.
 ```
 
-```text
-How saturated is the DEX vertical on Celo compared with other EVM chains?
-```
+## What's inside
 
-## What's included
+| Area | What you get |
+|------|--------------|
+| Network & contracts | Chain IDs, RPCs, explorers, fee currencies, and verified contract addresses |
+| Ecosystem intelligence | Product discovery, competitor scans, and vertical analysis |
+| Builder setup | Foundry, Hardhat, Viem, Wagmi, fee abstraction, and deploy & verify patterns |
+| DeFi | References for Uniswap, Aave, Morpho, Mento, Velodrome, Curve, Ubeswap, and stCELO |
+| MiniPay | Wallet detection, stablecoin payments, ODIS, templates, and listing guidance |
+| AI agents | ERC-8004, x402, the Celo MCP Server, and agent skill references |
+| Grants | Funding programs and grant matchmaking |
 
-| Area | Included references |
-|------|---------------------|
-| Network and contracts | Chain IDs, RPCs, explorers, fee currencies, RPC limits, and verified contract addresses |
-| Ecosystem intelligence | Product discovery, competitor scans, vertical analysis, and Celo ecosystem context |
-| Builder setup | Foundry, Hardhat, Viem, Wagmi, fee abstraction, deployment, and verification patterns |
-| DeFi | Protocol references for Uniswap, Aave, Morpho, Mento, Velodrome, Curve, Ubeswap, and stCELO |
-| MiniPay | Mini App development, wallet detection, stablecoin payments, ODIS, templates, and listing guidance |
-| AI agents | ERC-8004, x402, Celo MCP Server, and agent skill references |
-| Grants | Funding programs and grant matchmaking guidance |
-
-## Data sources
-
-Celopedia is curated from official Celo documentation, protocol references, ecosystem data sources, and live public APIs where applicable. Its sources include Celo Docs, The Grid, DefiLlama, Celoscan, MiniPay references, and protocol documentation from teams across the Celo ecosystem.
+Celopedia is curated from official Celo documentation, protocol references, and live public data sources including Celo Docs, The Grid, DefiLlama, and Celoscan.
 
 ## Resources
 

--- a/build-on-celo/index.mdx
+++ b/build-on-celo/index.mdx
@@ -21,8 +21,8 @@ Whether you're building your first dApp or looking to integrate an existing prot
 ## Getting Started
 
 <Columns cols={2}>
-    <Card title="Quickstart" href="/build/quickstart" arrow>
-        Quickstart with Celo Composer CLI
+    <Card title="Quickstart" href="/build-on-celo/build-with-ai/celopedia" arrow>
+        Get started fast with Celopedia
     </Card>
     <Card title="Deploy on Celo" href="/developer/deploy/index" arrow>
         Deploy a smart contract on Celo

--- a/build-on-celo/network-overview.mdx
+++ b/build-on-celo/network-overview.mdx
@@ -3,6 +3,8 @@ title: Network Information
 og:description: How to choose a Celo network based on your needs and objectives.
 ---
 
+import { AddNetworkButton } from '/snippets/AddNetworkButton.jsx';
+
 Overview of Celo Mainnet and the Celo Sepolia Testnet.
 
 ---
@@ -20,7 +22,7 @@ Overview of Celo Mainnet and the Celo Sepolia Testnet.
 | Block Explorers            | <ul><li>[https://explorer.celo.org](https://explorer.celo.org)</li><li>[https://celoscan.io](https://celoscan.io)</li></ul>                                                                               |
 | Bridge Link                | [List of bridges](/developer/bridges/bridges)                                                                                                                                                             |
 
-:::
+<AddNetworkButton network="mainnet" />
 
 ## Celo Sepolia Testnet
 
@@ -36,6 +38,8 @@ Overview of Celo Mainnet and the Celo Sepolia Testnet.
 | Block Explorer             | [https://celo-sepolia.blockscout.com](https://celo-sepolia.blockscout.com)                                                                             |
 | Bridge Link                | [https://testnets.superbridge.app](https://testnets.superbridge.app/?fromChainId=11155111&toChainId=11142220) <br/> Note: Ensure you enable Testnet in settings |
 | Faucet Links                | <ul><li>[https://cloud.google.com/application/web3/faucet/celo/sepolia](https://cloud.google.com/application/web3/faucet/celo/sepolia)</li><li>[https://faucet.celo.org/celo-sepolia](https://faucet.celo.org/celo-sepolia)</li></ul>                                                                                                                                              |
+
+<AddNetworkButton network="sepolia" />
 
 The Celo Sepolia Testnet is Celo's new developer testnet built on Ethereum Sepolia, designed to replace Alfajores following the planned Holesky deprecation in September 2025.
 

--- a/home/celo.mdx
+++ b/home/celo.mdx
@@ -3,11 +3,30 @@ title: "Celo"
 description: "Celo is a leading Ethereum L2. As the frontier chain for global impact, we're scaling real-world solutions for all."
 ---
 
-<Card title="Start Building" icon="rocket" href="/build-on-celo/quickstart">
+import { AddNetworkButton } from '/snippets/AddNetworkButton.jsx';
+
+<Card title="Start Building" icon="rocket" href="/build-on-celo/build-with-ai/celopedia">
   Build your first app on Celo. No coding experience required.
 </Card>
 
 ---
+
+## AI Agent Infrastructure
+
+<CardGroup cols={2}>
+  <Card title="ERC-8004: Agent Trust" icon="shield-check" href="/build-on-celo/build-with-ai/8004">
+    Establish trust infrastructure for autonomous AI agents with identity, reputation, and validation registries.
+  </Card>
+  <Card title="x402: Agent Payments" icon="money-bill-transfer" href="/build-on-celo/build-with-ai/x402">
+    Enable instant, permissionless micropayments for AI agents using stablecoins via HTTP 402.
+  </Card>
+  <Card title="MPP: Machine Payments" icon="credit-card" href="/build-on-celo/build-with-ai/mpp">
+    Charge USDC per API request over HTTP — gasless for the buyer, settled on-chain via a hosted facilitator.
+  </Card>
+  <Card title="Celopedia: Celo Skill" icon="book-open" href="https://celopedia.celo.org/">
+    Give your coding assistant Celo ecosystem knowledge — contract addresses, MiniPay, DeFi, grants, and agent infrastructure.
+  </Card>
+</CardGroup>
 
 ## Real World Use Cases
 
@@ -26,20 +45,6 @@ description: "Celo is a leading Ethereum L2. As the frontier chain for global im
   </Card>
 </CardGroup>
 
-## AI Agent Infrastructure
-
-<CardGroup cols={2}>
-  <Card title="ERC-8004: Agent Trust" icon="shield-check" href="/build-on-celo/build-with-ai/8004">
-    Establish trust infrastructure for autonomous AI agents with identity, reputation, and validation registries.
-  </Card>
-  <Card title="x402: Agent Payments" icon="money-bill-transfer" href="/build-on-celo/build-with-ai/x402">
-    Enable instant, permissionless micropayments for AI agents using stablecoins via HTTP 402.
-  </Card>
-  <Card title="MPP: Machine Payments" icon="credit-card" href="/build-on-celo/build-with-ai/mpp">
-    Charge USDC per API request over HTTP — gasless for the buyer, settled on-chain via a hosted facilitator.
-  </Card>
-</CardGroup>
-
 ## Builder Support
 
 <CardGroup cols={2}>
@@ -50,6 +55,15 @@ description: "Celo is a leading Ethereum L2. As the frontier chain for global im
     Discover grant opportunities and funding sources available in the Celo ecosystem.
   </Card>
 </CardGroup>
+
+## Add Celo to your wallet
+
+Connect your browser wallet to Celo in one click. See all network details on the [Network Information](/build-on-celo/network-overview) page.
+
+<div className="grid gap-x-4 gap-y-2 sm:grid-cols-2 mt-4">
+  <AddNetworkButton network="mainnet" />
+  <AddNetworkButton network="sepolia" />
+</div>
 
 ## Explore Developer Tools & Resources
 
@@ -74,7 +88,7 @@ description: "Celo is a leading Ethereum L2. As the frontier chain for global im
 
   <Accordion title="Build with Celo">
     <CardGroup cols={2}>
-      <Card title="Quickstart" icon="bolt" href="/build-on-celo/quickstart">
+      <Card title="Quickstart" icon="bolt" href="/build-on-celo/build-with-ai/celopedia">
         Build & Deploy your dApps in under 5 minutes
       </Card>
       <Card title="Tutorials" icon="graduation-cap" href="/build-on-celo">

--- a/snippets/AddNetworkButton.jsx
+++ b/snippets/AddNetworkButton.jsx
@@ -1,0 +1,123 @@
+export const AddNetworkButton = ({ network = "mainnet" }) => {
+  // Single source of truth for Celo network wallet_addEthereumChain params.
+  const NETWORKS = {
+    mainnet: {
+      title: "Add Celo Mainnet to your wallet",
+      desc: "Chain ID 42220 · CELO",
+      params: {
+        chainId: "0xa4ec", // 42220
+        chainName: "Celo Mainnet",
+        nativeCurrency: { name: "Celo", symbol: "CELO", decimals: 18 },
+        rpcUrls: ["https://forno.celo.org"],
+        blockExplorerUrls: ["https://celoscan.io"],
+      },
+    },
+    sepolia: {
+      title: "Add Celo Sepolia to your wallet",
+      desc: "Chain ID 11142220 · Testnet",
+      params: {
+        chainId: "0xaa044c", // 11142220 (lowercase hex — MetaMask rejects uppercase)
+        chainName: "Celo Sepolia",
+        nativeCurrency: { name: "Celo", symbol: "CELO", decimals: 18 },
+        rpcUrls: ["https://forno.celo-sepolia.celo-testnet.org"],
+        blockExplorerUrls: ["https://celo-sepolia.blockscout.com"],
+      },
+    },
+  };
+
+  const cfg = NETWORKS[network] || NETWORKS.mainnet;
+
+  const [status, setStatus] = useState(null); // { kind: "success" | "error" | "info", text }
+  const [pending, setPending] = useState(false);
+
+  const handleClick = async () => {
+    setStatus(null);
+
+    // Resolve the injected provider. With several wallets installed,
+    // window.ethereum can be a non-MetaMask provider that auto-rejects
+    // wallet_addEthereumChain — so prefer MetaMask when a list is exposed
+    // (mirrors @metamask/detect-provider, used by the Celo faucet button).
+    const eth = window.ethereum;
+    const provider =
+      eth && Array.isArray(eth.providers) && eth.providers.length
+        ? eth.providers.find((p) => p && p.isMetaMask) || eth.providers[0]
+        : eth;
+
+    if (!provider || !provider.request) {
+      setStatus({
+        kind: "info",
+        text: "No browser wallet detected. Install MetaMask, then try again.",
+      });
+      return;
+    }
+
+    setPending(true);
+    try {
+      await provider.request({
+        method: "wallet_addEthereumChain",
+        params: [cfg.params],
+      });
+      setStatus({ kind: "success", text: `${cfg.params.chainName} added to your wallet.` });
+    } catch (err) {
+      // Log the raw error so the exact code/message is visible in devtools.
+      console.error("wallet_addEthereumChain failed", err);
+      // 4001 is the EIP-1193 "user rejected request" code; anything else is a
+      // real failure, so surface the wallet's own message rather than masking it.
+      const text =
+        err && err.code === 4001
+          ? "Request cancelled in your wallet."
+          : `Couldn't add the network${err && err.message ? `: ${err.message}` : "."}`;
+      setStatus({ kind: "error", text });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const descText = pending ? "Opening your wallet…" : status ? status.text : cfg.desc;
+  const descColor =
+    status && status.kind === "error"
+      ? "text-red-600 dark:text-red-400"
+      : status && status.kind === "success"
+      ? "text-primary dark:text-primary-light"
+      : "text-gray-600 dark:text-gray-400";
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={pending}
+      aria-label={cfg.title}
+      className="card block font-normal group relative my-2 ring-2 ring-transparent rounded-2xl bg-white dark:bg-background-dark border border-gray-950/10 dark:border-white/10 overflow-hidden w-full text-left cursor-pointer hover:!border-primary dark:hover:!border-primary-light disabled:cursor-not-allowed"
+    >
+      <div className="px-6 py-5 relative">
+        <div className="h-6 w-6 text-primary dark:text-primary-light">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-6 w-6 shrink-0"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M8 12h8" />
+            <path d="M12 8v8" />
+          </svg>
+        </div>
+        <div>
+          <h2 className="not-prose font-semibold text-base text-gray-800 dark:text-white mt-4">
+            {cfg.title}
+          </h2>
+          <div className={`prose mt-1 font-normal text-base leading-6 ${descColor}`}>
+            <span>{descText}</span>
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+};

--- a/tooling/libraries-sdks/composer-kit.mdx
+++ b/tooling/libraries-sdks/composer-kit.mdx
@@ -215,6 +215,6 @@ For comprehensive examples and detailed API documentation for each component:
 
 ## Next Steps
 
-- Check out the [quickstart guide](/build/quickstart) to get started with Celo development
+- Get started with [Celopedia](/build-on-celo/build-with-ai/celopedia) to build on Celo with your AI coding assistant
 - Explore [building on MiniPay](/build/build-on-minipay/overview) for mobile-first experiences
 - Learn about [DeFi integration](/build/build-with-defi) for financial applications

--- a/tooling/overview/index.mdx
+++ b/tooling/overview/index.mdx
@@ -11,7 +11,7 @@ Explore our comprehensive suite of tools, guides, and resources designed to help
 
 Celo Composer allows you to quickly build, deploy, and iterate on decentralized applications using Celo. It provides a number of frameworks, examples, and Celo specific functionality to help you get started with your next dApp.
 
-- [Quickstart with Celo Composer](/build/quickstart)
+- [Get started with Celopedia](/build-on-celo/build-with-ai/celopedia)
 - [Celo Composer GitHub](https://github.com/celo-org/celo-composer)
 
 ## Developer Tools


### PR DESCRIPTION
## What & why

Two goals: give developers a one-click way to add Celo networks to their wallet, and reposition **Celopedia** as the primary "get started" entry point.

### 1. "Add Celo to your wallet" buttons
- New reusable snippet `snippets/AddNetworkButton.jsx` that calls `wallet_addEthereumChain` for **Celo Mainnet** and **Celo Sepolia**. Network params live in one place (single source of truth).
- Styled to be **visually identical to the homepage cards** — copied the live Mintlify card classes (theme tokens: `primary` / `primary-light` = the brand `#fcff52`), so it matches light/dark modes and the yellow hover-border behavior.
- Surfaced in two spots: a dedicated **"Add Celo to your wallet"** section on the homepage, and under each network table on the **Network Information** page.
- Provider handling mirrors the Celo faucet's `@metamask/detect-provider` approach (prefers MetaMask when multiple wallets are injected) and surfaces the wallet's real error instead of masking failures.

### 2. Homepage tidy-up
- Reordered sections: **AI Agent Infrastructure → Real World Use Cases → Builder Support → Networks**.
- Added a **Celopedia** card to AI Agent Infrastructure (links to celopedia.celo.org).

### 3. Get-started CTAs → Celopedia
Routed the prominent "Start Building" / "Quickstart" / "Get started" CTAs from the Celo Composer quickstart to the Celopedia page: homepage (both cards), `/tooling/overview`, `/build-on-celo` landing, and Composer Kit "Next Steps". Genuine step-by-step tutorial cross-links were intentionally left pointing at the Composer guide.

### 4. Celopedia page rewrite
Punchier hero, four value highlights (**find your idea, shape it, get feedback, go live fast**), a clear install CTA, and trimmed length.

## Verification
- `mint broken-links` passes.
- Rendered locally via `mint dev`; buttons, cards, and redirected CTAs confirmed in the output.
- ⚠️ Wallet click-flow still needs a manual browser test with an actual wallet — the add-network prompt can't be exercised headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)