### PR TITLE
docs: fix dark-mode background on Add-to-wallet buttons

### DIFF
--- a/snippets/AddNetworkButton.jsx
+++ b/snippets/AddNetworkButton.jsx
@@ -87,7 +87,7 @@ export const AddNetworkButton = ({ network = "mainnet" }) => {
       onClick={handleClick}
       disabled={pending}
       aria-label={cfg.title}
-      className="card block font-normal group relative my-2 ring-2 ring-transparent rounded-2xl bg-white dark:bg-background-dark border border-gray-950/10 dark:border-white/10 overflow-hidden w-full text-left cursor-pointer hover:!border-primary dark:hover:!border-primary-light disabled:cursor-not-allowed"
+      className="card block font-normal group relative my-2 ring-2 ring-transparent rounded-2xl bg-white dark:!bg-[#0b0d10] border border-gray-950/10 dark:border-white/10 overflow-hidden w-full text-left cursor-pointer hover:!border-primary dark:hover:!border-primary-light disabled:cursor-not-allowed"
     >
       <div className="px-6 py-5 relative">
         <div className="h-6 w-6 text-primary dark:text-primary-light">


### PR DESCRIPTION
## Problem

On the Docs Home page, the two **"Add Celo … to your wallet"** buttons rendered **white in dark mode** (they should be dark, matching the page background and the native `<Card>` components above them). Light mode was fine.

## Cause

In `snippets/AddNetworkButton.jsx`, the container used `dark:bg-background-dark`, which did not win over the Mintlify `.card` base white background — so `bg-white` showed through in dark mode. The element already forces its border with `!important` (`hover:!border-primary`), a hint the base `.card` styles need `!` to override.

## Fix

One-line change to the shared component:

- Before: `bg-white dark:bg-background-dark`
- After:  `bg-white dark:!bg-[#0b0d10]`

`#0b0d10` equals `docs.json` → `background.color.dark`, so the buttons match the page and native cards in dark mode. The `!important` guarantees the override. Light mode is unchanged.

Because both the **Home** tab (`home/celo.mdx`) and the **Build** tab (`build-on-celo/network-overview.mdx`) import this single snippet, all tabs are fixed at once.

## Verification

Ran `mint dev` locally and confirmed both buttons render dark in dark mode (subtle light border, matching native cards) and remain white in light mode, on both the Home page and `/build-on-celo/network-overview`. Hover border highlight still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)