### PR TITLE
docs: rename DIA oracle sidebar to "Using DIA", fix randomness links

### DIFF
--- a/tooling/oracles/dia.mdx
+++ b/tooling/oracles/dia.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using DIA Oracles
 og:description: Tutorial on how to use DIA Oracles on Celo
-sidebarTitle: "DIA"
+sidebarTitle: "Using DIA"
 ---
 
 [DIA](https://www.diadata.org) is a cross-chain, trustless oracle network delivering verifiable price feeds for Celo. DIA sources raw trade data directly from primary markets and computes it on-chain, ensuring complete transparency and data integrity.

--- a/tooling/oracles/index.mdx
+++ b/tooling/oracles/index.mdx
@@ -16,8 +16,9 @@ Here are lists of all on-chain Oracles:
 - [Celo Reserve Oracles](/legacy/protocol/stability/oracles)
 - [Supra](https://supraoracles.com/)
 - [Pyth Network](https://pyth.network/)
-  - Randomness
+  - [Randomness](https://docs.pyth.network/entropy/generate-random-numbers-evm#randomness-providers)
 - [Witnet](/developer/oracles/wit-oracle)
   - [Randomness](/developer/oracles/wit-oracle/#how-to-use-witnetrandomness)
 - [Quex Oracles](/developer/oracles/quex-oracles)
 - [DIA Oracles](/tooling/oracles/dia)
+  - [Randomness](/tooling/oracles/dia)


### PR DESCRIPTION
## Summary
Aligns the DIA oracle sidebar entry with the "Using X" naming convention used by the other oracle pages, and fixes the randomness links on the Oracle overview page.

## Changes
- **`tooling/oracles/dia.mdx`** — set `sidebarTitle` to `"Using DIA"` so the sidebar matches Using Band Protocol / Using Chainlink Oracles / Using RedStone / Using Supra / Using Quex.
- **`tooling/oracles/index.mdx`** — link Pyth Network's "Randomness" sub-item to the [Pyth entropy docs](https://docs.pyth.network/entropy/generate-random-numbers-evm#randomness-providers).
- **`tooling/oracles/index.mdx`** — add a "Randomness" sub-item under DIA Oracles (DIA offers a Randomness data product per its own page).

No `docs.json` change needed — navigation references pages by path, and the sidebar label comes from page frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)