### PR TITLE
docs(stablecoins): add cNGN documentation

### DIFF
--- a/build-on-celo/build-with-local-stablecoin.mdx
+++ b/build-on-celo/build-with-local-stablecoin.mdx
@@ -5,7 +5,7 @@ og:description: An overview of all stablecoins on Celo
 
 ### Celo Stablecoin Ecosystem  
 
-Celo supports a diverse range of fiat-referenced stablecoins designed for different regions and use cases, 6 USD-pegged and 26 regional currency-pegged stablecoins. The table below outlines their issuers and contract addresses across Celo Mainnet and Celo Sepolia.
+Celo supports a diverse range of fiat-referenced stablecoins designed for different regions and use cases, 6 USD-pegged and 27 regional currency-pegged stablecoins. The table below outlines their issuers and contract addresses across Celo Mainnet and Celo Sepolia.
 
 | Stablecoin       | Issuer                                                                  | Use Case                                          |Contract Address Mainnet|Contract Address Celo Sepolia Testnet|
 | ---------------- | ----------------------------------------------------------------------- | ------------------------------------------------- |-------------|---------|
@@ -36,6 +36,7 @@ Celo supports a diverse range of fiat-referenced stablecoins designed for differ
 | **USDGLO**       | [Glo Foundation](https://www.glodollar.org/)                            | Impact-driven stablecoin supporting global causes | [0x4f604735c1cf31399c6e711d5962b2b3e0225ad3](https://celoscan.io/address/0x4f604735c1cf31399c6e711d5962b2b3e0225ad3)  | -  |
 | **BRLA Digital** | [BRLA](https://brla.digital/)                                           | Brazil-based stablecoin                           | [0xfecb3f7c54e2caae9dc6ac9060a822d47e053760](https://celoscan.io/token/0xfecb3f7c54e2caae9dc6ac9060a822d47e053760)  |  - |
 | **COPM**         | [Minteo](https://minteo.com/)                                           | Fiat-backed Colombian Peso Stablecoin             |  [0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606](https://celoscan.io/token/0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606) | -  |
+| **cNGN**         | [Africa Stablecoin Consortium](https://cngn.co/)                        | Nigerian Naira-pegged stablecoin (regulated by Nigeria SEC) | [0xF6829D7393dAe24509eb1E52eE8e572e2E271a4f](https://celoscan.io/token/0xF6829D7393dAe24509eb1E52eE8e572e2E271a4f) | -  |
 | **wARS**         | [Ripio](https://ripio.com/)                                             | Argentine Peso-pegged stablecoin                  | [0x0dc4f92879b7670e5f4e4e6e3c801d229129d90d](https://celoscan.io/token/0x0dc4f92879b7670e5f4e4e6e3c801d229129d90d)  | -  |
 | **wBRL**         | [Ripio](https://ripio.com/)                                             | Brazilian Real-pegged stablecoin                  | [0xd76f5faf6888e24d9f04bf92a0c8b921fe4390e0](https://celoscan.io/token/0xd76f5faf6888e24d9f04bf92a0c8b921fe4390e0)  | -  |
 | **wMXN**         | [Ripio](https://ripio.com/)                                             | Mexican Peso-pegged stablecoin                    | [0x337e7456b420bd3481e7fa61fa9850343d610d34](https://celoscan.io/token/0x337e7456b420bd3481e7fa61fa9850343d610d34)  | -  |


### PR DESCRIPTION
## Summary
- Add cNGN (Nigerian Naira stablecoin, Africa Stablecoin Consortium) to the local stablecoin table, now that it has launched on Celo Mainnet at `0xF6829D7393dAe24509eb1E52eE8e572e2E271a4f`
- Bump the regional stablecoin count in the intro from 26 to 27

## Test plan
- [x] Verified the contract on-chain via `eth_call` (name/symbol decode to `cNGN`, decimals `6`)
- [x] Confirmed table markdown renders correctly