### PR TITLE
docs: surface llms.txt and the docs MCP server as AI entry points

### DIFF
--- a/build-on-celo/build-with-ai/mcp/index.mdx
+++ b/build-on-celo/build-with-ai/mcp/index.mdx
@@ -7,9 +7,11 @@ og:description: Learn about the Model Context Protocol and how to use Celo-speci
 
 ## Celo specific MCPs:
 
-- [Celo MPC Server](/build/build-with-ai/mcp/celo-mcp)
+- [Celo MCP Server](/build-on-celo/build-with-ai/mcp/celo-mcp)
   - Chain Info
   - Governance Proposals
+- [Celo Docs MCP Server](/build-on-celo/build-with-ai/use-docs-with-ai)
+  - Search the documentation from your editor
 
 <iframe
   src="https://www.youtube.com/embed/7XInE4Ll0as"

--- a/build-on-celo/build-with-ai/use-docs-with-ai.mdx
+++ b/build-on-celo/build-with-ai/use-docs-with-ai.mdx
@@ -1,0 +1,229 @@
+---
+title: "Use Celo Docs with AI Tools"
+sidebarTitle: "Docs for AI Tools"
+description: "Connect docs.celo.org to Claude Code, Cursor, VS Code, and ChatGPT using the docs MCP server, llms.txt, and per-page Markdown."
+---
+
+**Point your AI assistant at the docs instead of its training data.** Everything on docs.celo.org is available in machine-readable form — a hosted MCP server your editor can query live, a full-text index for pasting into a chat, and a Markdown version of every page.
+
+This matters because model training data goes stale. Celo became an Ethereum L2 in March 2025, contract addresses change, and assistants confidently repeat outdated L1 details. Connecting your tool to these endpoints means answers come from the current docs.
+
+| Entry point | URL | Best for |
+|-------------|-----|----------|
+| MCP server | `https://docs.celo.org/mcp` | Editors and agents — live search, no copy-paste |
+| Docs index | [`/llms.txt`](https://docs.celo.org/llms.txt) | Giving a chat a map of every docs page |
+| Full corpus | [`/llms-full.txt`](https://docs.celo.org/llms-full.txt) | Long-context models that can hold the whole docs set |
+| Any page as Markdown | append `.md` to any docs URL | Quoting one page as context |
+
+## Connect the docs MCP server
+
+The [Model Context Protocol](/build-on-celo/build-with-ai/mcp/index) lets an AI tool call external tools directly. Celo Docs hosts an MCP server at:
+
+```
+https://docs.celo.org/mcp
+```
+
+It uses streamable HTTP, needs no authentication, and exposes three tools:
+
+| Tool | What it does |
+|------|--------------|
+| `search_celo_docs` | Searches the docs for guides, references, and code examples |
+| `query_docs_filesystem_celo_docs` | Runs read-only queries against an in-memory filesystem of every docs page |
+| `submit_feedback` | Reports a problem with a page straight to the docs team |
+
+It also serves a **Celo Developer Playbook** skill resource — condensed guidance on deploying contracts, integrating wallets, fee abstraction, running nodes, and governance — which supporting clients load automatically.
+
+<Note>
+  This server answers questions about the **documentation**. To let an assistant read **live chain data** — balances, blocks, governance proposals — use the [Celo MCP Server](/build-on-celo/build-with-ai/mcp/celo-mcp) instead. The two are complementary, and you can run both.
+</Note>
+
+<Tabs>
+  <Tab title="Claude Code">
+    Add the server from your terminal:
+
+    ```bash
+    claude mcp add --transport http celo-docs https://docs.celo.org/mcp
+    ```
+
+    That registers it for the current project. To make it available everywhere, add `--scope user`:
+
+    ```bash
+    claude mcp add --transport http celo-docs --scope user https://docs.celo.org/mcp
+    ```
+
+    Confirm it connected with `/mcp` inside Claude Code.
+
+    **Try it:**
+
+    ```text
+    Using the Celo docs MCP server, which adapter address do I pass as
+    feeCurrency to pay gas in USDC on Celo mainnet?
+    ```
+
+    <Warning>
+      If you write `.mcp.json` by hand instead, the `type` field is required. An entry with a `url` but no `type` is read as a stdio server and skipped:
+
+      ```json
+      {
+        "mcpServers": {
+          "celo-docs": {
+            "type": "http",
+            "url": "https://docs.celo.org/mcp"
+          }
+        }
+      }
+      ```
+    </Warning>
+  </Tab>
+
+  <Tab title="Claude Desktop & claude.ai">
+    Remote MCP servers are added as **custom connectors**, not through a config file.
+
+    1. Open **Settings** → **Connectors**.
+    2. Click **Add** → **Add custom connector**.
+    3. Paste `https://docs.celo.org/mcp` and finish setup.
+
+    On Team and Enterprise plans an owner adds it under **Organization settings** → **Connectors** instead. Custom connectors are available on Free, Pro, Max, Team, and Enterprise plans; Free accounts are limited to one.
+
+    Claude connects from Anthropic's infrastructure rather than your machine, so the server has to be reachable on the public internet — `docs.celo.org` is.
+
+    **Try it:**
+
+    ```text
+    Search the Celo docs and summarize how transaction types on Celo
+    differ from standard Ethereum transactions.
+    ```
+  </Tab>
+
+  <Tab title="Cursor">
+    Add the server to `~/.cursor/mcp.json` to use it in every project, or to `.cursor/mcp.json` to scope it to one repo:
+
+    ```json
+    {
+      "mcpServers": {
+        "celo-docs": {
+          "url": "https://docs.celo.org/mcp"
+        }
+      }
+    }
+    ```
+
+    You can also reach the file from the command palette (<kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>) with **Open MCP settings** → **Add custom MCP**. The server then shows up under Settings → MCP; toggle it on if it isn't already.
+
+    **Try it:**
+
+    ```text
+    Check the Celo docs MCP server for the current Celo Sepolia chain ID
+    and RPC URL, then add the network to my viem config.
+    ```
+  </Tab>
+
+  <Tab title="VS Code">
+    GitHub Copilot in VS Code uses a different key (`servers`, not `mcpServers`) and does require `type`. Add to `.vscode/mcp.json`:
+
+    ```json
+    {
+      "servers": {
+        "celo-docs": {
+          "type": "http",
+          "url": "https://docs.celo.org/mcp"
+        }
+      }
+    }
+    ```
+
+    Open Copilot Chat in agent mode and the server's tools appear in the tool picker.
+
+    **Try it:**
+
+    ```text
+    Using the Celo docs, show me how to verify a contract on Celoscan
+    with Foundry.
+    ```
+  </Tab>
+
+  <Tab title="Codex">
+    Add the server to `~/.codex/config.toml`:
+
+    ```toml
+    [mcp_servers.celo-docs]
+    url = "https://docs.celo.org/mcp"
+    ```
+
+    **Try it:**
+
+    ```text
+    Look up in the Celo docs which stablecoins can be used as fee currencies
+    on mainnet, then list their addresses.
+    ```
+  </Tab>
+
+  <Tab title="ChatGPT">
+    ChatGPT has no one-click way to add an arbitrary MCP server, so start with the two paths that need no setup:
+
+    **Open a page in ChatGPT.** Every page in the docs has a contextual menu next to the page title with an **Open in ChatGPT** option. It starts a conversation with that page already loaded as context.
+
+    **Paste the docs index.** Give ChatGPT the index and let it pull the pages it needs:
+
+    ```text
+    Read https://docs.celo.org/llms.txt — it indexes every page of the Celo
+    documentation. Use it to find the pages covering fee abstraction, then
+    answer from those pages: how do I pay gas in USDC on Celo?
+    ```
+
+    <Info>
+      **Advanced:** ChatGPT's developer mode can connect arbitrary remote MCP servers, which would let you add `https://docs.celo.org/mcp` directly. OpenAI's documentation is inconsistent about which plans include it, availability has rolled out unevenly, and workspace admins can disable it — so check your own account under **Settings** → **Connectors** before relying on it. Note that ChatGPT's deep research connectors require an MCP server to expose tools named `search` and `fetch`; this server does not, so the deep research path will not work.
+    </Info>
+  </Tab>
+</Tabs>
+
+## llms.txt and llms-full.txt
+
+Two plain-text files make the whole documentation set readable by any model, with or without MCP support.
+
+<CardGroup cols={2}>
+  <Card title="llms.txt" icon="list" href="https://docs.celo.org/llms.txt">
+    An index of every page with its title and a link. Small enough to paste into any chat — the model reads it, then fetches only the pages it needs.
+  </Card>
+  <Card title="llms-full.txt" icon="book" href="https://docs.celo.org/llms-full.txt">
+    The entire documentation set concatenated into one file (~1.5 MB). Use it with long-context models when you want everything available at once.
+  </Card>
+</CardGroup>
+
+Reach for `llms.txt` by default. It costs a fraction of the tokens, and any tool that can follow a link will retrieve the specific pages it needs. Save `llms-full.txt` for when you genuinely want the full corpus in context and have the window to spare.
+
+[`llms.txt` follows the llmstxt.org convention](https://llmstxt.org/), a proposed standard for exposing site content to language models. `llms-full.txt` is a common companion file rather than part of that spec. The index is also served at [`/.well-known/llms.txt`](https://docs.celo.org/.well-known/llms.txt) for tools that look there.
+
+Both files are generated from the live site, so they never go stale.
+
+## Copy any page as Markdown
+
+Every page has a contextual menu beside its title:
+
+- **Copy page** — copies the page as Markdown, ready to paste as context.
+- **View as Markdown** — opens the raw Markdown source.
+- **Open in ChatGPT / Claude / Cursor / VS Code** — starts a session with the page as context, or installs the docs MCP server.
+- **Copy MCP server URL** — copies `https://docs.celo.org/mcp` to your clipboard.
+
+You can also skip the menu: **append `.md` to any docs URL** to get the Markdown directly. For example, [`docs.celo.org/build-on-celo/quickstart.md`](https://docs.celo.org/build-on-celo/quickstart.md). This works well in scripts and agent tooling that fetches URLs.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Celo MCP Server" icon="server" href="/build-on-celo/build-with-ai/mcp/celo-mcp">
+    Query live chain data — balances, blocks, tokens, NFTs, and governance proposals — from your editor.
+  </Card>
+  <Card title="Celopedia" icon="graduation-cap" href="/build-on-celo/build-with-ai/celopedia">
+    A skill that gives your coding assistant curated Celo knowledge: contract addresses, protocols, MiniPay, and grants.
+  </Card>
+  <Card title="What is MCP?" icon="plug" href="/build-on-celo/build-with-ai/mcp/index">
+    How the Model Context Protocol works and why AI tools use it.
+  </Card>
+  <Card title="Vibe Coding Tools" icon="wand-magic-sparkles" href="/build-on-celo/build-with-ai/vibe-coding">
+    AI-assisted development tools that work well for building on Celo.
+  </Card>
+</CardGroup>
+
+<Note>
+  Spotted something wrong on a page? Ask your assistant to use the `submit_feedback` tool — it reports the problem straight to the docs team. You can also [open an issue](https://github.com/celo-org/docs/issues).
+</Note>

--- a/build-on-celo/build-with-ai/vibe-coding.mdx
+++ b/build-on-celo/build-with-ai/vibe-coding.mdx
@@ -7,7 +7,7 @@ og:description: Learn how to set up your environment for Vibe Coding and discove
 
 Vibe Coding refers to an approach to software development where you use chat agents inside your IDE and build an application mainly by using prompts. This guide introduces you to a curated collection of tools that can significantly improve your development process, from full-stack application development to code editing and research.
 
-Watch a quick intro to Vibe Coding with the Celo MCP Servers. You can find out more about them in the [MCP section](/build/build-with-ai/mcp/index).
+Watch a quick intro to Vibe Coding with the Celo MCP Servers. You can find out more about them in the [MCP section](/build-on-celo/build-with-ai/mcp/index).
 
 <iframe
   src="https://www.youtube.com/embed/QOCO1G8cJyI"

--- a/contribute-to-celo/code-of-conduct.mdx
+++ b/contribute-to-celo/code-of-conduct.mdx
@@ -1,4 +1,0 @@
----
-title: Code of Conduct
-url: https://celo.org/code-of-conduct
----

--- a/contribute-to-celo/index.mdx
+++ b/contribute-to-celo/index.mdx
@@ -30,6 +30,7 @@ Welcome to the Celo Ecosystem! Whether you're a user, developer, founder, or con
 - [**Participate in the community:**](https://calendar.google.com/calendar/u/0/r?cid=c_asn0b4c1emdgsq3urlh2ei2dig@group.calendar.google.com) Add the Community Calendar
 - [**Contribute to local chapters:**](/contribute-to-celo/daos) Connect with the community, offer support, and mentor others.
 - [**Sign up for Celo Signal:**](https://share.hsforms.com/1Qrhush1vSA2WIamd_yL4ow53n4j) If you are a Node Operator, Dapp Running Its Own Node, Exchange or Custodian, Owner who is Staking and Participating in Governance, or a Core Developer or Contributor
+- [**Read the Code of Conduct:**](https://celo.org/code-of-conduct) The standards everyone in the Celo community is expected to uphold.
 
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -697,7 +697,7 @@
   "redirects": [
     {
       "source": "/tooling/overview/faucet",
-      "destination": "/tooling/testnets/celo-sepolia/index"
+      "destination": "https://faucet.celo.org/celo-sepolia"
     },
     {
       "source": "/tooling/nodes/run-a-celo-node",

--- a/docs.json
+++ b/docs.json
@@ -8,7 +8,7 @@
     "dark": "#000000"
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude", "cursor"]
+    "options": ["copy", "view", "mcp", "chatgpt", "claude", "cursor", "vscode"]
   },
   "background": {
     "color": {
@@ -128,6 +128,7 @@
             "group": "Build with AI",
             "pages": [
               "build-on-celo/build-with-ai/overview",
+              "build-on-celo/build-with-ai/use-docs-with-ai",
               {
                 "group": "Agent Infrastructure",
                 "pages": [
@@ -190,7 +191,6 @@
             "group": "Overview",
             "pages": [
               "tooling/overview/index",
-              "tooling/overview/faucet",
               "tooling/bridges/bridges",
               "tooling/bridges/cross-chain-messaging",
               "tooling/testnets/celo-sepolia/index"
@@ -200,7 +200,6 @@
             "group": "Nodes",
             "pages": [
               "tooling/nodes/overview",
-              "tooling/nodes/run-a-celo-node",
               "tooling/nodes/forno",
               "tooling/nodes/alchemy"
             ]
@@ -244,9 +243,7 @@
             "pages": [
               "tooling/explorers/overview",
               "tooling/explorers/block-explorers",
-              "tooling/explorers/analytics",
-              "tooling/explorers/blockscout",
-              "tooling/explorers/celoscan"
+              "tooling/explorers/analytics"
             ]
           },
           {
@@ -370,8 +367,7 @@
             "pages": [
               "contribute-to-celo/index",
               "contribute-to-celo/builders",
-              "contribute-to-celo/daos",
-              "contribute-to-celo/code-of-conduct"
+              "contribute-to-celo/daos"
             ]
           },
           {
@@ -506,7 +502,6 @@
             "pages": [
               "legacy/overview",
               "legacy/l1-architecture",
-              "legacy/whitepapers",
               "legacy/faq"
             ]
           },
@@ -637,14 +632,7 @@
               "legacy/validator/proxy",
               "legacy/validator/validator-explorer",
               "legacy/validator/celo-foundation-voting-policy",
-              "legacy/validator/troubleshooting-faq",
-              {
-                "group": "External",
-                "pages": [
-                  "legacy/validator/celo-website",
-                  "legacy/validator/discord"
-                ]
-              }
+              "legacy/validator/troubleshooting-faq"
             ]
           }
         ]
@@ -652,6 +640,11 @@
     ],
     "global": {
       "anchors": [
+        {
+          "anchor": "Docs for AI",
+          "href": "/build-on-celo/build-with-ai/use-docs-with-ai",
+          "icon": "robot"
+        },
         {
           "anchor": "Organization",
           "href": "https://celo.org/",
@@ -702,6 +695,38 @@
     "dark": "/images/CeloDocs_LogoDark.svg"
   },
   "redirects": [
+    {
+      "source": "/tooling/overview/faucet",
+      "destination": "/tooling/testnets/celo-sepolia/index"
+    },
+    {
+      "source": "/tooling/nodes/run-a-celo-node",
+      "destination": "/infra-partners/operators/run-node"
+    },
+    {
+      "source": "/tooling/explorers/blockscout",
+      "destination": "/tooling/explorers/block-explorers"
+    },
+    {
+      "source": "/tooling/explorers/celoscan",
+      "destination": "/tooling/explorers/block-explorers"
+    },
+    {
+      "source": "/contribute-to-celo/code-of-conduct",
+      "destination": "/contribute-to-celo/index"
+    },
+    {
+      "source": "/legacy/whitepapers",
+      "destination": "/legacy/overview"
+    },
+    {
+      "source": "/legacy/validator/celo-website",
+      "destination": "/legacy/validator/index"
+    },
+    {
+      "source": "/legacy/validator/discord",
+      "destination": "/legacy/validator/index"
+    },
     {
       "source": "/blog/2022/01/08/valora-wc-v1",
       "destination": "/"
@@ -1792,7 +1817,7 @@
     },
     {
       "source": "/developer/build-with-ai/overview",
-      "destination": "/build/build-with-ai/overview"
+      "destination": "/build-on-celo/build-with-ai/overview"
     },
     {
       "source": "/developer/evm-tools",
@@ -3028,7 +3053,7 @@
     },
     {
       "source": "/learn/celo-whitepapers",
-      "destination": "/legacy/whitepapers"
+      "destination": "/legacy/overview"
     },
     {
       "source": "/learn/developer-onboarding",
@@ -3144,7 +3169,7 @@
     },
     {
       "source": "/build/mcp/composer-mcp",
-      "destination": "/build-on-celo/build-with-ai/mcp/composer-mcp"
+      "destination": "/build-on-celo/build-with-ai/mcp/index"
     },
     {
       "source": "/build/support",

--- a/docs.json
+++ b/docs.json
@@ -713,19 +713,19 @@
     },
     {
       "source": "/contribute-to-celo/code-of-conduct",
-      "destination": "/contribute-to-celo/index"
+      "destination": "https://celo.org/code-of-conduct"
     },
     {
       "source": "/legacy/whitepapers",
-      "destination": "/legacy/overview"
+      "destination": "https://celo.org/papers"
     },
     {
       "source": "/legacy/validator/celo-website",
-      "destination": "/legacy/validator/index"
+      "destination": "https://celo.org"
     },
     {
       "source": "/legacy/validator/discord",
-      "destination": "/legacy/validator/index"
+      "destination": "https://discord.com/invite/celo"
     },
     {
       "source": "/blog/2022/01/08/valora-wc-v1",

--- a/legacy/overview.mdx
+++ b/legacy/overview.mdx
@@ -34,3 +34,5 @@ The table below summarizes the technical changes involved in transitioning from 
 | **Finality**        | One block finality, instantaneous once block is produced.                                    | Finality depends on trust in sequencer, batcher, proposer, and eigenDA, or ultimately on Ethereum.            |
 
 For more detailed technical changes, see [Celo's L2 Migration Documentation](/specs/l2-migration).
+
+For the original research behind the Celo L1 design, see the [Celo whitepapers](https://celo.org/papers).

--- a/legacy/validator/celo-website.mdx
+++ b/legacy/validator/celo-website.mdx
@@ -1,4 +1,0 @@
----
-title: Celo Website
-url: https://celo.org
----

--- a/legacy/validator/discord.mdx
+++ b/legacy/validator/discord.mdx
@@ -1,4 +1,0 @@
----
-title: Celo Discord
-url: https://discord.com/invite/celo
----

--- a/legacy/whitepapers.mdx
+++ b/legacy/whitepapers.mdx
@@ -1,4 +1,0 @@
----
-title: Whitepapers
-url: https://celo.org/papers
----

--- a/tooling/explorers/blockscout.mdx
+++ b/tooling/explorers/blockscout.mdx
@@ -1,4 +1,0 @@
----
-title: Blockscout
-url: "https://celo.blockscout.com/"
----

--- a/tooling/explorers/celoscan.mdx
+++ b/tooling/explorers/celoscan.mdx
@@ -1,4 +1,0 @@
----
-title: Celoscan
-url: "https://celoscan.io/"
----

--- a/tooling/nodes/run-a-celo-node.mdx
+++ b/tooling/nodes/run-a-celo-node.mdx
@@ -1,4 +1,0 @@
----
-title: Run a Celo Node
-url: https://docs.celo.org/cel2/operators/run-node
----

--- a/tooling/overview/faucet.mdx
+++ b/tooling/overview/faucet.mdx
@@ -1,4 +1,0 @@
----
-title: Faucet
-url: https://faucet.celo.org/celo-sepolia
----


### PR DESCRIPTION
Makes docs.celo.org usable from AI tooling. The site already exposes an MCP server, `llms.txt`, `llms-full.txt`, and per-page Markdown — none of it was documented anywhere a developer would find it. Everything here works on the current Mintlify plan; no upgrade involved.

## New page

**[Use Celo Docs with AI Tools](https://docs.celo.org/build-on-celo/build-with-ai/use-docs-with-ai)** — top of **Build on Celo → Build with AI**, plus a **"Docs for AI"** global anchor so it's one click from anywhere in the docs.

- **MCP setup per client** — Claude Code, Claude Desktop/claude.ai, Cursor, VS Code, Codex, ChatGPT — each with a worked example query. The config shapes are published separately because they are genuinely not interchangeable: Claude Code requires `"type": "http"` (omitting it is a hard error), Cursor's docs use `url` alone, VS Code uses `servers` rather than `mcpServers`.
- **`llms.txt` vs `llms-full.txt`** — what each is for, and the "append `.md` to any docs URL" shortcut.
- **Related cards** to the Celo MCP Server (chain data) and Celopedia (skill), so the three aren't confused.

ChatGPT leads with the zero-setup paths. Developer-mode MCP is deliberately hedged — OpenAI documents plan availability inconsistently across its own pages — and the page states outright that deep research **won't** work, since that requires tools named `search`/`fetch` which this server doesn't expose.

## llms.txt fixes

**Removed 8 external-link stub pages** (`title` + `url` frontmatter only). Mintlify's sitemap excludes these; `llms.txt` does not. Their `.md` URLs redirected off-domain and served **~2.28 MB of third-party HTML** advertised as Celo documentation — `legacy/validator/celo-website.md` alone returned 1.19 MB of celo.org marketing.

All eight were redundant with existing pages or global anchors, with zero inbound internal links (verified). Redirects added for each, and `/learn/celo-whitepapers` retargeted so it doesn't become a 404 chain.

| Removed | Covered by |
|---|---|
| `tooling/explorers/{blockscout,celoscan}` | `tooling/explorers/block-explorers` |
| `tooling/overview/faucet` | "Faucet" global anchor |
| `tooling/nodes/run-a-celo-node` | `infra-partners/operators/run-node` (the stub pointed at a dead path) |
| `contribute-to-celo/code-of-conduct` | inline link added to Joining Celo |
| `legacy/whitepapers` | inline link added to the Legacy overview |
| `legacy/validator/{celo-website,discord}` | "Organization" + "Support" global anchors |

**Also fixed:** two dead `/build/build-with-ai/mcp/*` links, a "Celo **MPC** Server" typo, and two redirects targeting pages that don't exist.

**Config:** added `mcp` and `vscode` to `contextual.options`.

## Audit results

The audit premise turned out to be wrong in a useful way — **nav coverage was already perfect**: 271/271 pages present, zero stale entries, zero `_deprecated/` leakage, all 271 URLs returning 200. The real defects were different:

| Defect | Status |
|---|---|
| 8 stub pages leaking 2.28 MB of third-party HTML | **Fixed here** |
| `## OpenAPI Specs` section links a hard 404 | **Not fixable from this repo** — no `api`/`openapi` key in `docs.json`, no `api-reference/` dir, zero occurrences of `openapi` in the tree. Emitted from stale server-side state; needs a Mintlify support ticket |
| 97% of entries have no description | **Follow-up PR** — Mintlify's generator reads only `description:` and ignores `og:description:`. Policy agreed: non-legacy → `description:`, `legacy/**` keeps `og:description:` so legacy L1 docs aren't surfaced to LLMs |

Two smaller finds also deferred: a duplicate nav entry (`legacy/protocol/identity/odis-use-case-phone-number-privacy`, listed twice) and four ambiguous title collisions.

## Verification

- `npx mintlify broken-links` — **passes** (run after every edit)
- `mint dev` — page returns 200, all six tabs render, no MDX errors; sidebar entry and global anchor render on unrelated pages; deleted paths return 307
- Nav integrity: 264 unique pages (271 − 8 + 1), no entries without a file on disk, no remaining `url:` frontmatter pages in nav
- MCP endpoint confirmed live: `serverInfo: {"name":"Celo Docs","version":"1.0.0"}`, tools `search_celo_docs` / `query_docs_filesystem_celo_docs` / `submit_feedback`

**One thing that can't be verified before deploy:** `mint dev` doesn't generate `.md` endpoints, `llms.txt`, or `/mcp` — those come from the hosting layer. So "Copy page as Markdown" and "Open in Claude" appear broken in local preview (they fetch a `.md` URL that 404s locally). Confirmed working in production on existing pages: `docs.celo.org/home/protocol.md` → 200 `text/markdown`. Worth re-checking on the preview deploy.

### Reviewer checklist

- [ ] MCP endpoint verified working in **Claude Code** — `claude mcp add --transport http celo-docs https://docs.celo.org/mcp`
- [ ] MCP endpoint verified working in **Cursor**
- [ ] "Copy page as Markdown" verified on the preview deploy

Try the page's own example — *"Using the Celo docs MCP server, which adapter address do I pass as `feeCurrency` to pay gas in USDC on Celo mainnet?"* The answer is `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B`, so a wrong one is obvious.

## Out of scope

In-page chat widget, any Mintlify plan upgrade, Discord/Telegram bots. Announcement (Discord + newsletter) to follow once this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)