### PR TITLE
docs(nodes): add NOWNodes as Celo RPC provider

### DIFF
--- a/tooling/nodes/overview.mdx
+++ b/tooling/nodes/overview.mdx
@@ -211,7 +211,7 @@ https://getblock.io/nodes/celo/
 
 ### NOWNodes
 
-[NOWNodes](https://nownodes.io/) provides managed Celo RPC access with geo-balanced infrastructure, automatic failover, 24/7 support, and support for advanced debug methods.
+[NOWNodes](https://nownodes.io/) is a managed RPC provider. Their Celo endpoints support debug methods.
 
 #### Supported Networks
 

--- a/tooling/nodes/overview.mdx
+++ b/tooling/nodes/overview.mdx
@@ -208,3 +208,15 @@ https://onfinality.io/networks/celo
 <Card href="https://getblock.io/nodes/celo/" arrow title="GetBlock">
 https://getblock.io/nodes/celo/
 </Card>
+
+### NOWNodes
+
+[NOWNodes](https://nownodes.io/) provides managed Celo RPC access with geo-balanced infrastructure, automatic failover, 24/7 support, and support for advanced debug methods.
+
+#### Supported Networks
+
+- Celo Mainnet
+
+<Card href="https://nownodes.io/nodes/celo-celo" arrow title="NOWNodes">
+https://nownodes.io/nodes/celo-celo
+</Card>


### PR DESCRIPTION
Celo RPC Provider Documentation Update
The hole, and the fix

NOWNodes is currently missing from the list of Celo RPC providers.

This PR adds NOWNodes as a managed Celo Mainnet RPC provider, with a link to the Celo-specific service page and information about supported debug methods.

What this does NOT do / residual risk

Documentation-only change. It does not modify Celo network functionality, node software, or application code.

Judgement calls

None.

Issues

None.

Stacking / conflicts

Branched off main and independent of other PRs.

Verification evidence
Confirmed Celo Mainnet is supported by NOWNodes.
Confirmed Celo RPC access is available.
Confirmed debug methods are supported.
Confirmed the linked NOWNodes Celo product page is available.
No application tests were run because this is a documentation-only change.
Remaining ops steps

None

Checklist

Title is the commit message I want on main

Judgement calls / bundled product changes flagged above (or "none")

README / runbook / .env.example / examples / error strings updated for the world this creates — N/A, documentation-only provider listing

No secrets in the diff

Questions for the maintainer marked clearly at the end (or "none")

Questions for the maintainer: none.