### PR TITLE
fix(nav): remove duplicate odis-use-case-phone-number-privacy entry from the Legacy ODIS group

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -578,7 +578,6 @@
                   {
                     "group": "ODIS",
                     "pages": [
-                      "legacy/protocol/identity/odis-use-case-phone-number-privacy",
                       {
                         "group": "Use Cases",
                         "pages": [


### PR DESCRIPTION
## The hole, and the fix

`legacy/protocol/identity/odis-use-case-phone-number-privacy` was listed twice in `docs.json` navigation: once directly under the **ODIS** group (line 581) and again inside its nested **Use Cases** sub-group (line 585), next to its sibling `odis-use-case-key-hardening`. The sidebar showed the page twice. This deletes the group-level copy; the nested one is the right home because its sibling lives there.

## What this does NOT do / residual risk

One-line deletion in the Legacy nav block; no content, redirects or other nav touched. The whole Legacy block is removed later by #2254 — this just stops the double entry until then.

## Judgement calls

Kept the nested entry, dropped the group-level one (the page is a "use case", same as its sibling). Reversible by swapping which line is deleted.

## Issues

Closes #2240 — the single acceptance condition (no duplicate nav entries) is met and checked below.

## Stacking / conflicts

Branched off `main`, independent. #2254 will delete this block wholesale; if it lands first this PR becomes a no-op and can be closed.

## Verification evidence

```
$ python3 …  # walk navigation, count raw vs unique page entries
nav entries: 264 raw, 264 unique; duplicates: []
$ git diff --stat
 docs.json | 1 -
$ mint broken-links   # on 6ccbcb6b
success no broken links found
```
Before this change on `main` (`bdf40b37`): 265 raw, 264 unique.

## Remaining ops steps

- [ ] none

## Checklist

- [x] Title is the commit message I want on `main`
- [x] `mint broken-links` passes; nav has no duplicates
- [x] No secrets in the diff
