### PR TITLE
docs: point banner at Agents at Work Hackathon

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -20,7 +20,7 @@
     "default": "dark"
   },
   "banner": {
-    "content": "📬 **Next agent hackathon starts Aug 28** | Subscribe to the Celo Devs newsletter for hackathon updates. [Subscribe](https://celo-devs.beehiiv.com/subscribe)",
+    "content": "🤖 **Agents at Work Hackathon** | Build agents that move real money on Celo — $5,000 in prizes, kicks off Aug 28. [Join the hackathon](https://celoplatform.notion.site/Agents-at-Work-Hackathon-3c1d5cb803de81139de7f4f3d09e55dc)",
     "dismissible": true
   },
   "fonts": {


### PR DESCRIPTION
## What

Updates the site-wide banner in `docs.json` to a clear call-to-action to join the **Agents at Work Hackathon**, replacing the previous newsletter-signup teaser.

New banner copy:

> 🤖 **Agents at Work Hackathon** | Build agents that move real money on Celo — $5,000 in prizes, kicks off Aug 28. [Join the hackathon](https://celoplatform.notion.site/Agents-at-Work-Hackathon-3c1d5cb803de81139de7f4f3d09e55dc)

## Details

- CTA links to the Notion hackathon hub (full details + tracks).
- Keeps the established banner structure (emoji + bold title + `|` + sentence + Markdown link) and `dismissible: true`.
- Single-line change to `banner.content`; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)