### PR TITLE
docs(operate): one Discord support sentence, and past tense for op-geth

### DIFF
--- a/operate/index.mdx
+++ b/operate/index.mdx
@@ -4,10 +4,10 @@ sidebarTitle: "Start here"
 description: Run and maintain a Celo L2 node, read the protocol specification, and track the upgrades that affect operators
 ---
 
-This section is for node operators, RPC providers, and readers of the Celo L2 protocol specification. The fastest path to a synced node is [Run a node with Docker](/operate/operators/run-node). Ask in [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) on [Discord](https://chat.celo.org) if you get stuck.
+This section is for node operators, RPC providers, and readers of the Celo L2 protocol specification. The fastest path to a synced node is [Run a node with Docker](/operate/operators/run-node). Ask in [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) on [Discord](https://chat.celo.org) if you have any questions.
 
 <Warning>
-Celo is replacing `op-geth` with `op-reth` as its execution client. See [End of Support for op-geth](/operate/notices/op-geth-deprecation) for each network's switch date.
+Celo has replaced `op-geth` with `op-reth` as its execution client. See [End of Support for op-geth](/operate/notices/op-geth-deprecation) for each network's switch date.
 </Warning>
 
 ## Run a node

--- a/operate/notices/archive/celo-sepolia-launch.mdx
+++ b/operate/notices/archive/celo-sepolia-launch.mdx
@@ -86,6 +86,6 @@ Thank you to the first wave of our ecosystem partners supporting Celo Sepolia al
 - **Talent Protocol** – Web3 Professional Network
 - **Prosperity Pass** – Celo PG Onchain Access Pass
 
-## Getting Help
+## Getting help
 
-Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+Ask in [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) on [Discord](https://chat.celo.org) if you have any questions.

--- a/operate/notices/archive/l1-fusaka-upgrade.mdx
+++ b/operate/notices/archive/l1-fusaka-upgrade.mdx
@@ -34,6 +34,6 @@ There are no upgrades required for the Celo L2 client for the L1 Fusaka upgrade.
 - `op-node` at [v2.1.0](https://github.com/celo-org/optimism/releases/tag/celo-v2.1.0)
 - `eigenda-proxy` at [v1.8.2](https://github.com/layr-labs/eigenda/pkgs/container/eigenda-proxy/437919973?tag=v1.8.2)
 
-## Getting Help
+## Getting help
 
-Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+Ask in [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) on [Discord](https://chat.celo.org) if you have any questions.

--- a/operate/operators/overview.mdx
+++ b/operate/operators/overview.mdx
@@ -25,12 +25,12 @@ See [Architecture](/operate/operators/architecture) for how these fit together.
 ## Execution client
 
 - **op-reth** — Celo's primary execution client, built on `reth`. The guides in this section use `op-reth`.
-- **op-geth** — the previous execution client. It is deprecated in favor of `op-reth` and remains supported only until your network's switch date.
+- **op-geth** — the previous execution client. Support ended on each network's switch date; a node still running it can follow the wrong chain.
 
 <Warning>
-**op-geth is being deprecated**
+**op-geth is no longer supported**
 
-Celo is switching its execution client from `op-geth` to `op-reth`. All node operators must migrate to `op-reth` by their network's switch date. See [End of Support for op-geth](/operate/notices/op-geth-deprecation) for the switch dates and details, and follow the [celo-l2-node-docker-compose](https://github.com/celo-org/celo-l2-node-docker-compose) repository for release updates.
+Celo has replaced `op-geth` with `op-reth` as its execution client. A node still running `op-geth` can follow the wrong chain. See [End of Support for op-geth](/operate/notices/op-geth-deprecation) for the switch dates and details, and follow the [celo-l2-node-docker-compose](https://github.com/celo-org/celo-l2-node-docker-compose) repository for release updates.
 </Warning>
 
 ## Guides
@@ -47,4 +47,4 @@ Celo is switching its execution client from `op-geth` to `op-reth`. All node ope
 
 ## Getting help
 
-Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+Ask in [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) on [Discord](https://chat.celo.org) if you have any questions.

--- a/operate/operators/troubleshooting.mdx
+++ b/operate/operators/troubleshooting.mdx
@@ -39,6 +39,6 @@ If your node stalls or falls behind the sequencer, it usually has too few peers.
 
 See the [Configuration reference](/operate/operators/configuration#networking-p2p) for these variables. Because op-node now syncs via the execution layer, healthy execution-client peer connectivity is required — see [Deprecation of Req/Res CL P2P Sync](/operate/notices/req-resp-cl-sync-deprecation).
 
-## Getting Help
+## Getting help
 
-Please reach out to our team on [Discord](https://chat.celo.org) in the [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) channel if you have any questions.
+Ask in [#celo-L2-support](https://discord.com/channels/600834479145353243/1286649605798367252) on [Discord](https://chat.celo.org) if you have any questions.


### PR DESCRIPTION
Four Operate pages pointed readers at `#celo-L2-support` in a longer sentence than the landing page added in #2308 used for the same thing, so the tab read two ways. All five now carry one sentence. The landing page is in the diff because leaving it on its own wording would move the inconsistency rather than remove it, and AGENTS.md says a page that conflicts with the standard is the page that gets fixed. While in these files I also put the op-geth switch in the past tense, since both switch dates have passed.

## The support sentence

"Ask in #celo-L2-support on Discord if you have any questions", on `operate/index.mdx`, `operate/operators/overview.mdx`, `operate/operators/troubleshooting.mdx`, `operate/notices/archive/l1-fusaka-upgrade.mdx` and `operate/notices/archive/celo-sepolia-launch.mdx`.

The two archived notices are in scope. They are still published pages a reader can land on, and the edit is one line each with no link changes.

Three of the pages also said `## Getting Help`. AGENTS.md asks for sentence case on pages you are already editing, so they now say `## Getting help`. The slug stays `#getting-help`, so no anchors break.

## The op-geth tense

`/operate/notices/op-geth-deprecation` gives the switch dates as June 24, 2026 for Celo Sepolia and July 22, 2026 for mainnet. Both are past, so "Celo is replacing op-geth" and "op-geth is being deprecated" were announcing something that already happened. The landing page and the operators overview now say it happened, and the overview's Warning says what an operator still running `op-geth` risks, which the notice already states at line 19.

The deprecation notice itself is future tense start to finish, as are `run-node.mdx:12` and `archive-node.mdx:16`. That needs a rewrite rather than a verb swap, so it is issue #2311 rather than more of this diff.

## Verification

```
$ mint broken-links
success no broken links found

$ git grep 'reach out to our team on Discord' -- '*.mdx'
(no hits)
```

Closes #2309
