### PR TITLE
docs(stablecoins): update VNX website link from vnx.li to vnx.io

### DIFF
--- a/build-on-celo/build-with-local-stablecoin.mdx
+++ b/build-on-celo/build-with-local-stablecoin.mdx
@@ -41,7 +41,7 @@ Alongside Mento, independent issuers have deployed stablecoins on Celo:
 | [Tether](https://tether.to/en/) | USD₮ |
 | [Anchorage Digital Bank](https://usat.io/) | [USA₮](/build-on-celo/build-with-usat) |
 | [Ripio](https://ripio.com/) | wARS, wBRL, wMXN, wCOP, wPEN, wCLP |
-| [VNX](https://vnx.li/) | vGBP, vCHF |
+| [VNX](https://vnx.io/) | vGBP, vCHF |
 | [Africa Stablecoin Consortium](https://cngn.co/) | cNGN |
 | [Angle](https://www.angle.money/) | USDA, EURA |
 | [Mountain Protocol](https://mountainprotocol.com/) | USDM |

--- a/tooling/contracts/stablecoin-contracts.mdx
+++ b/tooling/contracts/stablecoin-contracts.mdx
@@ -41,8 +41,8 @@ These addresses are listed for convenience and do not imply any endorsement of t
 | **USDA** | [Angle](https://www.angle.money/) | [`0x0000206329b97DB379d5E1Bf586BbDB969C63274`](https://celo.blockscout.com/address/0x0000206329b97DB379d5E1Bf586BbDB969C63274) | - |
 | **USDGLO** | [Glo Foundation](https://www.glodollar.org/) | [`0x4f604735c1cf31399c6e711d5962b2b3e0225ad3`](https://celo.blockscout.com/address/0x4f604735c1cf31399c6e711d5962b2b3e0225ad3) | - |
 | **USDM** | [Mountain Protocol](https://mountainprotocol.com/) | [`0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C`](https://celo.blockscout.com/address/0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C) | - |
-| **vCHF** | [VNX](https://vnx.li/) | [`0xc5ebea9984c485ec5d58ca5a2d376620d93af871`](https://celo.blockscout.com/address/0xc5ebea9984c485ec5d58ca5a2d376620d93af871) | - |
-| **vGBP** | [VNX](https://vnx.li/) | [`0x7ae4265ecfc1f31bc0e112dfcfe3d78e01f4bb7f`](https://celo.blockscout.com/address/0x7ae4265ecfc1f31bc0e112dfcfe3d78e01f4bb7f) | - |
+| **vCHF** | [VNX](https://vnx.io/) | [`0xc5ebea9984c485ec5d58ca5a2d376620d93af871`](https://celo.blockscout.com/address/0xc5ebea9984c485ec5d58ca5a2d376620d93af871) | - |
+| **vGBP** | [VNX](https://vnx.io/) | [`0x7ae4265ecfc1f31bc0e112dfcfe3d78e01f4bb7f`](https://celo.blockscout.com/address/0x7ae4265ecfc1f31bc0e112dfcfe3d78e01f4bb7f) | - |
 | **wARS** | [Ripio](https://ripio.com/) | [`0x0dc4f92879b7670e5f4e4e6e3c801d229129d90d`](https://celo.blockscout.com/address/0x0dc4f92879b7670e5f4e4e6e3c801d229129d90d) | - |
 | **wBRL** | [Ripio](https://ripio.com/) | [`0xd76f5faf6888e24d9f04bf92a0c8b921fe4390e0`](https://celo.blockscout.com/address/0xd76f5faf6888e24d9f04bf92a0c8b921fe4390e0) | - |
 | **wCLP** | [Ripio](https://ripio.com/) | [`0x61D450a098b6a7f69fC4b98CE68198fe59768651`](https://celo.blockscout.com/address/0x61D450a098b6a7f69fC4b98CE68198fe59768651) | - |


### PR DESCRIPTION
## What

VNX moved its website from vnx.li to vnx.io. Replaces the three remaining links to the old domain:

- `build-on-celo/build-with-local-stablecoin.mdx` (VNX row in the issuer table)
- `tooling/contracts/stablecoin-contracts.mdx` (vCHF and vGBP rows)

No other content changes. Both domains currently return 200, so this is a freshness fix rather than a broken link.

## Verification

```
$ mint broken-links
success no broken links found

$ grep -rn "vnx\.li" . --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.context
(no output)

$ curl -sI https://vnx.io/ | head -1
HTTP/2 200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)