### PR TITLE
docs(nodes): add BoltRPC as Celo RPC provider

### DIFF
--- a/tooling/nodes/overview.mdx
+++ b/tooling/nodes/overview.mdx
@@ -220,3 +220,15 @@ https://getblock.io/nodes/celo/
 <Card href="https://nownodes.io/nodes/celo-celo" arrow title="NOWNodes">
 https://nownodes.io/nodes/celo-celo
 </Card>
+
+### BoltRPC
+
+[BoltRPC](https://boltrpc.io) is a multi-chain RPC provider operated by [Matrixed.Link](https://matrixed.link). Celo Mainnet is served as a full archive node with HTTPS, WebSocket, and debug methods. Operations are ISO/IEC 27001:2022 certified.
+
+#### Supported Networks
+
+- Celo Mainnet
+
+<Card href="https://boltrpc.io/networks/celo" arrow title="BoltRPC">
+https://boltrpc.io/networks/celo
+</Card>


### PR DESCRIPTION
## Summary

- Add BoltRPC to the As a Service RPC provider list on `/tooling/nodes/overview`
- Celo Mainnet only (full archive, HTTPS, WebSocket, debug methods); operated by Matrixed.Link

## Test plan

- [ ] Name link opens https://boltrpc.io
- [ ] Operator link opens https://matrixed.link
- [ ] Card opens https://boltrpc.io/networks/celo
- [ ] Section renders after NOWNodes under As a Service