### PR TITLE
docs(exchanges): add EIDEX to the CELO exchange list

### DIFF
--- a/home/exchanges.mdx
+++ b/home/exchanges.mdx
@@ -26,6 +26,7 @@ Be sure you understand and review the risks when swapping assets.
 - [Uniswap](https://app.uniswap.org/)
 - [Velodrome](https://velodrome.finance/)
 - [Other Exchanges](https://coinmarketcap.com/currencies/celo/)
+- [EIDEX](https://eidex.io/screener/celo-celo-to-usdt-erc20) - Compares live CELO swap quotes across exchange providers
 
 #### Celo Specific Exchanges
 


### PR DESCRIPTION
<!--
TITLE = the commit on main (squash-merge, PR title). Conventional Commits, scoped, imperative, OUTCOME:
  fix(buy): block buying ocean pixels via long-press inspect path   ✅     fix buy bug   ❌
One concern per PR. Every sentence below is a claim that will be checked against the code.
Rules: .claude/shared/engineering-rules.md §2–3.  Tip: /write-pr fills this in for you.
-->

## The hole, and the fix

The list covers centralized venues, DEXs and Celo-native swaps, but there is nothing that shows what different providers actually quote before you pick one.

Adds EIDEX under Decentralized Exchanges, right after the existing "Other Exchanges" line. You put in an amount, it shows live CELO quotes from the providers side by side, sorted by what you get out. No account, no signup - the swap itself happens on the provider's own site.

## What this does NOT do / residual risk

One line of docs. No code, no config, nothing in the build.

Right now the linked page resolves CELO to USDT through three providers (ChangeNOW, StealthEX, Exolix). So it is not "every exchange", only the ones that quote CELO.

## Judgement calls

Put it under Decentralized Exchanges instead of adding a heading, since "Other Exchanges" already sits there and that one is a comparison link too, not a DEX. Move it wherever you prefer.

## Issues

None.

## Stacking / conflicts

Off main, no other PRs open from me. One file.

## Verification evidence

Opened the page and checked it returns quotes at 10, 100 and 1000 CELO.
Loads without an account.
No tests - docs only.

## Remaining ops steps

- [ ] none

## Checklist

- [x] Title is the commit message I want on main
- [x] Judgement calls flagged above
- [x] No secrets in the diff

Questions for the maintainer: none.